### PR TITLE
New features: Support for Discord permissions and roles, option to disable 'not found' embed, and more.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.kaktushose</groupId>
     <artifactId>jda-commands</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/github/kaktushose/jda/commands/api/EmbedCache.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/api/EmbedCache.java
@@ -10,9 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.*;
 import java.lang.reflect.Type;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,6 +27,7 @@ public class EmbedCache {
     private static final Logger log = LoggerFactory.getLogger(EmbedCache.class);
     private static final Gson gson = new Gson();
     private final File file;
+    private final InputStream stream;
     private Map<String, EmbedDTO> embedMap;
 
     /**
@@ -39,6 +38,18 @@ public class EmbedCache {
     public EmbedCache(File file) {
         embedMap = new ConcurrentHashMap<>();
         this.file = file;
+        this.stream = null;
+    }
+
+    /**
+     * Constructs a new EmbedCache object.
+     *
+     * @param stream the stream to load the embeds from
+     */
+    public EmbedCache(InputStream stream) {
+        embedMap = new ConcurrentHashMap<>();
+        this.stream = stream;
+        this.file = null;
     }
 
     /**
@@ -47,7 +58,16 @@ public class EmbedCache {
     @SuppressWarnings("UnstableApiUsage")
     public void loadEmbedsToCache() {
         try {
-            JsonReader jsonReader = new JsonReader(new FileReader(file));
+            Reader reader;
+            if (file != null) {
+                reader = new FileReader(file);
+            } else if (stream != null) {
+                reader = new InputStreamReader(stream);
+            } else {
+                throw new IllegalArgumentException("File and stream are null!");
+            }
+
+            JsonReader jsonReader = new JsonReader(reader);
             Type type = new TypeToken<Map<String, EmbedDTO>>() {
             }.getType();
             embedMap = gson.fromJson(jsonReader, type);

--- a/src/main/java/com/github/kaktushose/jda/commands/api/EmbedFactory.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/api/EmbedFactory.java
@@ -3,8 +3,10 @@ package com.github.kaktushose.jda.commands.api;
 import com.github.kaktushose.jda.commands.entities.CommandCallable;
 import com.github.kaktushose.jda.commands.entities.CommandList;
 import com.github.kaktushose.jda.commands.entities.CommandSettings;
+import com.github.kaktushose.jda.commands.internal.Patterns;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 
 import javax.annotation.Nonnull;
@@ -12,6 +14,7 @@ import java.awt.*;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
 /**
  * The default embed factory of this framework. An embed factory provides a bunch of embeds that are frequently needed.
@@ -112,9 +115,20 @@ public class EmbedFactory {
      * @return the MessageEmbed to send
      */
     public MessageEmbed getInsufficientPermissionsEmbed(@Nonnull CommandCallable commandCallable, @Nonnull CommandSettings settings, @Nonnull GuildMessageReceivedEvent event) {
-        StringBuilder sbPermissions = new StringBuilder();
-        commandCallable.getPermissions().forEach(permission -> sbPermissions.append(permission).append(", "));
-        String permissions = sbPermissions.toString().isEmpty() ? "N/A" : sbPermissions.substring(0, sbPermissions.length() - 2);
+        String perm = commandCallable.getPermissions().stream()
+                .map(permission -> {
+                    final Matcher matcher = Patterns.getJDAPermissionPattern().matcher(permission);
+
+                    if (matcher.matches()) {
+                        return matcher.group(1).toUpperCase();
+                    } else if (settings.getAllPermissionRoles().containsKey(permission)) {
+                        Role role = event.getGuild().getRoleById(settings.getPermissionRole(permission));
+                        if (role == null) return "Unknown role";
+                        return role.getAsMention();
+                    }
+
+                    return permission;
+                }).collect(Collectors.joining(", "));
 
         return new EmbedBuilder()
                 .setColor(Color.RED)
@@ -123,7 +137,7 @@ public class EmbedFactory {
                         settings.getPrefix(),
                         commandCallable.getLabels().get(0)))
                 .addField("Permissions:",
-                        String.format("`%s`", permissions), false
+                        String.format("%s", perm), false
                 ).build();
     }
 

--- a/src/main/java/com/github/kaktushose/jda/commands/api/JsonEmbedFactory.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/api/JsonEmbedFactory.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import java.io.File;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -35,6 +36,16 @@ public class JsonEmbedFactory extends EmbedFactory {
      */
     public JsonEmbedFactory(File file) {
         embedCache = new EmbedCache(file);
+        embedCache.loadEmbedsToCache();
+    }
+
+    /**
+     * Constructs a new JsonEmbedFactory.
+     *
+     * @param stream the json to load the embeds from.
+     */
+    public JsonEmbedFactory(InputStream stream) {
+        embedCache = new EmbedCache(stream);
         embedCache.loadEmbedsToCache();
     }
 

--- a/src/main/java/com/github/kaktushose/jda/commands/entities/CommandSettings.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/entities/CommandSettings.java
@@ -33,13 +33,13 @@ public class CommandSettings {
     private final Set<String> prefixAliases;
     private boolean botMentionPrefix;
     private String prefix;
-    private boolean ignoreBots, ignoreLabelCase;
+    private boolean ignoreBots, ignoreLabelCase, embedAtNotFound;
 
     /**
      * Constructs a new CommandSettings object with default values.
      */
     public CommandSettings() {
-        this("!", true, true, true);
+        this("!", true, true, true, true);
     }
 
     /**
@@ -49,13 +49,15 @@ public class CommandSettings {
      * @param ignoreBots       whether the framework should ignore messages from Discord Bots or not
      * @param ignoreLabelCase  whether the command mapper should be case sensitive or not
      * @param botMentionPrefix whether to allow a bot mention to be a valid prefix or not
+     * @param embedAtNotFound  whether to send an embed at a non-existing command or not
      */
-    public CommandSettings(@Nullable String prefix, boolean ignoreBots, boolean ignoreLabelCase, boolean botMentionPrefix) {
+    public CommandSettings(@Nullable String prefix, boolean ignoreBots, boolean ignoreLabelCase, boolean botMentionPrefix, boolean embedAtNotFound) {
         this.prefix = validatePrefix(prefix);
         this.prefixAliases = new HashSet<>();
         this.ignoreBots = ignoreBots;
         this.ignoreLabelCase = ignoreLabelCase;
         this.botMentionPrefix = botMentionPrefix;
+        this.embedAtNotFound = embedAtNotFound;
         mutedChannels = ConcurrentHashMap.newKeySet();
         mutedUsers = ConcurrentHashMap.newKeySet();
         permissionHolders = new ConcurrentHashMap<>();
@@ -218,4 +220,23 @@ public class CommandSettings {
         return prefix;
     }
 
+    /**
+     * Whether to send an embed at a non-existing command or not.
+     *
+     * @return {@code true} if it should send an embed at a non-existing command
+     */
+    public boolean isEmbedAtNotFound() {
+        return embedAtNotFound;
+    }
+
+    /**
+     * Set if it should send an embed at a non-existing command or not.
+     *
+     * @param embedAtNotFound {@code true} if it should send an embed at a non-existing command
+     * @return the current instance to use fluent interface
+     */
+    public CommandSettings setEmbedAtNotFound(boolean embedAtNotFound) {
+        this.embedAtNotFound = embedAtNotFound;
+        return this;
+    }
 }

--- a/src/main/java/com/github/kaktushose/jda/commands/entities/CommandSettings.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/entities/CommandSettings.java
@@ -34,7 +34,9 @@ public class CommandSettings {
     private final Set<String> prefixAliases;
     private boolean botMentionPrefix;
     private String prefix;
-    private boolean ignoreBots, ignoreLabelCase, embedAtNotFound;
+    private boolean ignoreBots;
+    private boolean ignoreLabelCase;
+    private boolean embedAtNotFound;
 
     /**
      * Constructs a new CommandSettings object with default values.

--- a/src/main/java/com/github/kaktushose/jda/commands/entities/CommandSettings.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/entities/CommandSettings.java
@@ -30,6 +30,7 @@ public class CommandSettings {
     private final Set<Long> mutedUsers;
     private final Set<String> helpLabels;
     private final Map<String, Set<Long>> permissionHolders;
+    private final Map<String, Long> permissionRoles;
     private final Set<String> prefixAliases;
     private boolean botMentionPrefix;
     private String prefix;
@@ -61,6 +62,7 @@ public class CommandSettings {
         mutedChannels = ConcurrentHashMap.newKeySet();
         mutedUsers = ConcurrentHashMap.newKeySet();
         permissionHolders = new ConcurrentHashMap<>();
+        permissionRoles = new ConcurrentHashMap<>();
         helpLabels = ConcurrentHashMap.newKeySet();
         helpLabels.add("help");
     }
@@ -110,6 +112,17 @@ public class CommandSettings {
     }
 
     /**
+     * Get the role for the given permission.
+     *
+     * @param permission the permission to get the role for
+     * @return the id of the role
+     * @see com.github.kaktushose.jda.commands.annotations.Permission
+     */
+    public Long getPermissionRole(@Nonnull String permission) {
+        return permissionRoles.get(permission);
+    }
+
+    /**
      * Get a Map of all permissions and their holders. Key: the String representing a permission. Value: a
      * Set of the ids of all users with the permission. This Map is mutable and thus can be modified in
      * order to add or remove permissions and their holders.
@@ -118,6 +131,16 @@ public class CommandSettings {
      */
     public Map<String, Set<Long>> getAllPermissionHolders() {
         return permissionHolders;
+    }
+
+    /**
+     * Get a Map of all permissions and their roles. Key: the String representing a permission. Value: a
+     * The id of the role
+     *
+     * @return a mutable Map containing all permissions and the ids of the roles with the permissions
+     */
+    public Map<String, Long> getAllPermissionRoles() {
+        return permissionRoles;
     }
 
     /**

--- a/src/main/java/com/github/kaktushose/jda/commands/entities/JDACommandsBuilder.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/entities/JDACommandsBuilder.java
@@ -54,7 +54,7 @@ public class JDACommandsBuilder {
     }
 
     private JDACommandsBuilder(Object jda, boolean isShardManager) {
-        this.defaultSettings = new CommandSettings("!", true, true, true);
+        this.defaultSettings = new CommandSettings("!", true, true, true, true);
         this.guildSettings = new HashMap<>();
         this.eventParser = new EventParser();
         this.commandMapper = new CommandMapper();
@@ -95,7 +95,7 @@ public class JDACommandsBuilder {
      */
     public static JDACommands start(@Nonnull JDA jda, @Nullable String prefix) {
         return new JDACommandsBuilder(jda)
-                .setDefaultSettings(new CommandSettings(prefix, true, true, true))
+                .setDefaultSettings(new CommandSettings(prefix, true, true, true, true))
                 .build();
     }
 
@@ -108,7 +108,7 @@ public class JDACommandsBuilder {
      */
     public static JDACommands start(@Nonnull ShardManager shardManager, @Nullable String prefix) {
         return new JDACommandsBuilder(shardManager)
-                .setDefaultSettings(new CommandSettings(prefix, true, true, true))
+                .setDefaultSettings(new CommandSettings(prefix, true, true, true, true))
                 .build();
     }
 
@@ -120,11 +120,12 @@ public class JDACommandsBuilder {
      * @param ignoreBots       whether the framework should ignore messages from Discord Bots or not
      * @param ignoreLabelCase  whether the command mapper should be case sensitive or not
      * @param botMentionPrefix whether to allow a bot mention to be a valid prefix or not
+     * @param embedAtNotFound  whether to send an embed at a non-existing command or not
      * @return a {@link JDACommands} instance that has started the initialization process
      */
-    public static JDACommands start(@Nonnull JDA jda, @Nullable String prefix, boolean ignoreBots, boolean ignoreLabelCase, boolean botMentionPrefix) {
+    public static JDACommands start(@Nonnull JDA jda, @Nullable String prefix, boolean ignoreBots, boolean ignoreLabelCase, boolean botMentionPrefix, boolean embedAtNotFound) {
         return new JDACommandsBuilder(jda)
-                .setDefaultSettings(new CommandSettings(prefix, ignoreBots, ignoreLabelCase, botMentionPrefix))
+                .setDefaultSettings(new CommandSettings(prefix, ignoreBots, ignoreLabelCase, botMentionPrefix, embedAtNotFound))
                 .build();
     }
 
@@ -136,11 +137,12 @@ public class JDACommandsBuilder {
      * @param ignoreBots       whether the framework should ignore messages from Discord Bots or not
      * @param ignoreLabelCase  whether the command mapper should be case sensitive or not
      * @param botMentionPrefix whether to allow a bot mention to be a valid prefix or not
+     * @param embedAtNotFound  whether to send an embed at a non-existing command or not
      * @return a {@link JDACommands} instance that has started the initialization process
      */
-    public static JDACommands start(@Nonnull ShardManager shardManager, @Nullable String prefix, boolean ignoreBots, boolean ignoreLabelCase, boolean botMentionPrefix) {
+    public static JDACommands start(@Nonnull ShardManager shardManager, @Nullable String prefix, boolean ignoreBots, boolean ignoreLabelCase, boolean botMentionPrefix, boolean embedAtNotFound) {
         return new JDACommandsBuilder(shardManager)
-                .setDefaultSettings(new CommandSettings(prefix, ignoreBots, ignoreLabelCase, botMentionPrefix))
+                .setDefaultSettings(new CommandSettings(prefix, ignoreBots, ignoreLabelCase, botMentionPrefix, embedAtNotFound))
                 .build();
     }
 

--- a/src/main/java/com/github/kaktushose/jda/commands/internal/CommandDispatcher.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/internal/CommandDispatcher.java
@@ -120,7 +120,7 @@ public final class CommandDispatcher extends ListenerAdapter {
             return;
         }
 
-        String[] input = eventParser.parseEvent(event, settings);
+        String[] input = eventParser.parseEvent(event);
 
         if (input.length == 1 && input[0].isEmpty()) {
             return;

--- a/src/main/java/com/github/kaktushose/jda/commands/internal/CommandDispatcher.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/internal/CommandDispatcher.java
@@ -114,7 +114,7 @@ public final class CommandDispatcher extends ListenerAdapter {
         if (!eventParser.validateEvent(event, settings)) {
 
             if (settings.getMutedUsers().contains(event.getAuthor().getIdLong())) {
-                event.getChannel().sendMessage(embedFactory.getUserMutedEmbed(settings, event));
+                event.getChannel().sendMessage(embedFactory.getUserMutedEmbed(settings, event)).queue();
             }
 
             return;
@@ -141,7 +141,7 @@ public final class CommandDispatcher extends ListenerAdapter {
         Optional<CommandCallable> command = commandMapper.findCommand(commands, input, settings.isIgnoreLabelCase());
         if (!command.isPresent()) {
             log.debug("No command for input {} found", Arrays.toString(input));
-            event.getChannel().sendMessage(embedFactory.getCommandNotFoundEmbed(settings, event)).queue();
+            if (settings.isEmbedAtNotFound()) event.getChannel().sendMessage(embedFactory.getCommandNotFoundEmbed(settings, event)).queue();
             return;
         }
         CommandCallable commandCallable = command.get();

--- a/src/main/java/com/github/kaktushose/jda/commands/internal/Patterns.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/internal/Patterns.java
@@ -1,0 +1,11 @@
+package com.github.kaktushose.jda.commands.internal;
+
+import java.util.regex.Pattern;
+
+public class Patterns {
+    private static final Pattern JDAPermissionPattern = Pattern.compile("\\{@@([\\w]+)}");
+
+    public static Pattern getJDAPermissionPattern() {
+        return JDAPermissionPattern;
+    }
+}

--- a/src/main/java/com/github/kaktushose/jda/commands/internal/Patterns.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/internal/Patterns.java
@@ -3,7 +3,7 @@ package com.github.kaktushose.jda.commands.internal;
 import java.util.regex.Pattern;
 
 public class Patterns {
-    private static final Pattern JDAPermissionPattern = Pattern.compile("\\{@@([\\w]+)}");
+    private static final Pattern JDAPermissionPattern = Pattern.compile("\\{([\\w]+)}");
 
     public static Pattern getJDAPermissionPattern() {
         return JDAPermissionPattern;


### PR DESCRIPTION
This PR bumps JDA-Commands to 1.1.2.

**New features:**
- You can now disable the 'command not found' embed in the CommandSettings. This allows to add an option (per guild) to disable the message or not.
- The JsonEmbedFactory can now also load from an InputStream, to support loading from JAR resources.
- You can now use Discord permissions (like ADMINISTRATOR) or Roles for commands.

---

**Discord permissions:**
Use the `@Permission` annotation with the following format: `{@@ADMINISTRATOR}`.

**Roles:**
Use `CommandSettings#getPermissionRole` or `CommandSettings#getAllPermissionRoles` to add an role by name -> ID (long). Then you can use that name in the `@Permission` annotation. If the role is not found, it will automatically fallback to the given name in the 'no permission' embed.