### PR TITLE
`EventParser` will now check if the `botMentionPrefix` is set to true

### DIFF
--- a/src/main/java/com/github/kaktushose/jda/commands/api/EventParser.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/api/EventParser.java
@@ -50,12 +50,14 @@ public class EventParser {
             return true;
         }
 
-        User selfUser = event.getJDA().getSelfUser();
-        List<User> mentionedUsers = event.getMessage().getMentionedUsers();
-        if (mentionedUsers.size() > 0) {
-            if (mentionedUsers.get(0).equals(selfUser)) {
-                usedPrefix = String.format("<@!%s>", selfUser.getId());
-                return true;
+        if (settings.isBotMentionPrefix()) {
+            User selfUser = event.getJDA().getSelfUser();
+            List<User> mentionedUsers = event.getMessage().getMentionedUsers();
+            if (mentionedUsers.size() > 0) {
+                if (mentionedUsers.get(0).equals(selfUser)) {
+                    usedPrefix = String.format("<@!%s>", selfUser.getId());
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
I noticed that `validateEvent` in `EventParser` didn't check if the `CommandSettings` had the `botMentionPrefix` value set to true. Means it validated a Command that had the Bot Mention, even if this was manually set to false.