### PR TITLE
'CommandDispatcher' will now check if a Message starts with a prefix

### DIFF
--- a/src/main/java/com/github/kaktushose/jda/commands/api/EventParser.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/api/EventParser.java
@@ -49,7 +49,7 @@ public class EventParser {
 
         String message = event.getMessage().getContentDisplay();
         String prefix = settings.getPrefix();
-        if (message.startsWith(prefix) || settings.getPrefixAliases().stream().anyMatch(message::startsWith)) {
+        if (startsWithPrefix(message, settings)) {
             usedPrefix = settings.getPrefixAliases().stream().filter(message::startsWith).findFirst().orElse(prefix);
             return true;
         }
@@ -108,6 +108,17 @@ public class EventParser {
                 return settings.getPermissionHolders(permission).contains(event.getAuthor().getIdLong());
             }
         });
+    }
+
+    /**
+     * Checks if the {@code Message} starts with the prefix, or it's alternatives in {@link CommandSettings}
+     * @param message the {@link String} to check on
+     * @param settings the {@link CommandSettings} to use the prefixes from
+     * @return {@code true} if the Message starts with a prefix
+     */
+    public boolean startsWithPrefix(String message, CommandSettings settings) {
+        String prefix = settings.getPrefix();
+        return message.startsWith(prefix) || settings.getPrefixAliases().stream().anyMatch(message::startsWith);
     }
 
 }

--- a/src/main/java/com/github/kaktushose/jda/commands/internal/CommandDispatcher.java
+++ b/src/main/java/com/github/kaktushose/jda/commands/internal/CommandDispatcher.java
@@ -113,7 +113,7 @@ public final class CommandDispatcher extends ListenerAdapter {
         CommandSettings settings = getSettings(event.getGuild().getIdLong());
         if (!eventParser.validateEvent(event, settings)) {
 
-            if (settings.getMutedUsers().contains(event.getAuthor().getIdLong())) {
+            if (eventParser.startsWithPrefix(event.getMessage().getContentDisplay(), settings) && settings.getMutedUsers().contains(event.getAuthor().getIdLong())) {
                 event.getChannel().sendMessage(embedFactory.getUserMutedEmbed(settings, event)).queue();
             }
 


### PR DESCRIPTION
This is a quick fix I tried to make for #30 