### PR TITLE
[FEATURE] Support filtering auto complete for specific options

### DIFF
--- a/core/src/main/java/com/github/kaktushose/jda/commands/annotations/interactions/AutoComplete.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/annotations/interactions/AutoComplete.java
@@ -44,6 +44,20 @@ import java.lang.annotation.Target;
 ///         event.replyChoices(...);
 ///     }
 ///     ```
+///
+/// **Be aware that the example above will register *every* command option with auto complete enabled.** If you want to
+/// avoid that, you have to explicitly state the command options the handler supports:
+/// ```java
+/// @SlashCommand("favourite food")
+/// public void foodCommand(CommandEvent event, String fruit, String vegetable) {
+///     event.reply("You've chosen: %s and %s", fruit, vegetable);
+/// }
+///
+/// @AutoComplete(vale = "foodCommand", options = "fruit")
+/// public void onFruitAutoComplete(AutoCompleteEvent event) {
+///     event.replyChoices(...);
+/// }
+/// ```
 /// @see SlashCommand
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -53,5 +67,10 @@ public @interface AutoComplete {
     ///
     /// @return the slash commands
     String[] value();
+
+    /// Returns the name of the command options this autocomplete should handle
+    ///
+    /// @return the command options
+    String[] options() default "";
 
 }

--- a/core/src/main/java/com/github/kaktushose/jda/commands/annotations/interactions/AutoComplete.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/annotations/interactions/AutoComplete.java
@@ -58,6 +58,10 @@ import java.lang.annotation.Target;
 ///     event.replyChoices(...);
 /// }
 /// ```
+/// You can have multiple auto complete handler for the same slash command, but each command option can only have
+/// exactly *one* handler.
+/// If an auto complete handler doesn't specify any command options, it will be registered implicitly for every command
+/// option of the given slash command(s), unless an explicit auto complete handler exists for that command option.
 /// @see SlashCommand
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/AutoCompleteDefinition.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/AutoCompleteDefinition.java
@@ -24,7 +24,7 @@ public record AutoCompleteDefinition(@NotNull ClassDescription classDescription,
     ///
     /// @param command the name of the slash command or the name of the method handling the command
     /// @param options a possibly-empty Set of the names of the options the auto complete should exclusively handle. If
-    ///                               empty, the auto complete will handle every option of the given command.
+    ///                                                                                                                                        empty, the auto complete will handle every option of the given command.
     public record AutoCompleteRule(@NotNull String command, @NotNull Set<String> options) {}
 
     /// Builds a new [AutoCompleteDefinition] from the given class and method description.
@@ -37,18 +37,13 @@ public record AutoCompleteDefinition(@NotNull ClassDescription classDescription,
         if (Helpers.checkSignature(method, List.of(AutoCompleteEvent.class))) {
             return Optional.empty();
         }
-        return method.annotation(AutoComplete.class).map(autoComplete -> {
-                    Set<AutoCompleteRule> rules = new HashSet<>();
-                    for (String command : autoComplete.value()) {
-                        rules.add(new AutoCompleteRule(command, Arrays.stream(autoComplete.options())
+        return method.annotation(AutoComplete.class).map(autoComplete ->
+                new AutoCompleteDefinition(clazz, method, Arrays.stream(autoComplete.value())
+                        .map(command -> new AutoCompleteRule(command, Arrays.stream(autoComplete.options())
                                 .filter(it -> !it.isBlank())
                                 .collect(Collectors.toSet()))
-                        );
-                    }
-                    return new AutoCompleteDefinition(clazz, method, rules);
-                }
-        );
-
+                        ).collect(Collectors.toSet())
+                ));
     }
 
     @NotNull

--- a/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/AutoCompleteDefinition.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/AutoCompleteDefinition.java
@@ -14,10 +14,10 @@ import java.util.stream.Collectors;
 ///
 /// @param classDescription  the [ClassDescription] of the declaring class of the [#methodDescription()]
 /// @param methodDescription the [MethodDescription] of the method this definition is bound to
-/// @param commands          the commands this autocomplete handler can handle
+/// @param rules          the rules this autocomplete handler can handle
 public record AutoCompleteDefinition(@NotNull ClassDescription classDescription,
                                      @NotNull MethodDescription methodDescription,
-                                     @NotNull Set<AutoCompleteRule> commands)
+                                     @NotNull Set<AutoCompleteRule> rules)
         implements InteractionDefinition {
 
     /// Representation of an auto complete rule.

--- a/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/InteractionRegistry.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/InteractionRegistry.java
@@ -87,7 +87,7 @@ public record InteractionRegistry(@NotNull Validators validators,
                 .toList();
 
         autoCompletes.stream()
-                .map(AutoCompleteDefinition::commands)
+                .map(AutoCompleteDefinition::rules)
                 .flatMap(Collection::stream)
                 .filter(rule -> commandDefinitions.stream().noneMatch(command ->
                         command.name().startsWith(rule.command()) || command.methodDescription().name().equals(rule.command()))

--- a/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/InteractionRegistry.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/InteractionRegistry.java
@@ -89,9 +89,9 @@ public record InteractionRegistry(@NotNull Validators validators,
         autoCompletes.stream()
                 .map(AutoCompleteDefinition::commands)
                 .flatMap(Collection::stream)
-                .filter(name -> commandDefinitions.stream().noneMatch(command ->
-                        command.name().startsWith(name) || command.methodDescription().name().equals(name))
-                ).forEach(s -> log.warn("No Command found for auto complete {}", s));
+                .filter(rule -> commandDefinitions.stream().noneMatch(command ->
+                        command.name().startsWith(rule.command()) || command.methodDescription().name().equals(rule.command()))
+                ).forEach(s -> log.warn("No slash commands found matching {}", s));
 
 
         return interactionDefinitions;

--- a/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/command/OptionDataDefinition.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/command/OptionDataDefinition.java
@@ -8,6 +8,7 @@ import com.github.kaktushose.jda.commands.annotations.interactions.Param;
 import com.github.kaktushose.jda.commands.definitions.Definition;
 import com.github.kaktushose.jda.commands.definitions.description.ParameterDescription;
 import com.github.kaktushose.jda.commands.definitions.features.JDAEntity;
+import com.github.kaktushose.jda.commands.definitions.interactions.AutoCompleteDefinition;
 import com.github.kaktushose.jda.commands.dispatching.validation.Validator;
 import com.github.kaktushose.jda.commands.dispatching.validation.internal.Validators;
 import net.dv8tion.jda.api.entities.Member;
@@ -36,7 +37,7 @@ import static java.util.Map.entry;
 ///
 /// @param type         the [Class] type of the parameter
 /// @param optional     whether this parameter is optional
-/// @param autoComplete whether this parameter supports autocomplete
+/// @param autoComplete he [AutoCompleteDefinition] for this option or `null` if no auto complete was defined
 /// @param defaultValue the default value of this parameter or `null`
 /// @param name         the name of the parameter
 /// @param description  the description of the parameter
@@ -45,7 +46,7 @@ import static java.util.Map.entry;
 public record OptionDataDefinition(
         @NotNull Class<?> type,
         boolean optional,
-        boolean autoComplete,
+        @Nullable AutoCompleteDefinition autoComplete,
         @Nullable String defaultValue,
         @NotNull String name,
         @NotNull String description,
@@ -96,12 +97,12 @@ public record OptionDataDefinition(
     /// Builds a new [OptionDataDefinition].
     ///
     /// @param parameter         the [ParameterDescription] to build the [OptionDataDefinition] from
-    /// @param autoComplete      whether the [ParameterDescription] should support autocomplete
+    /// @param autoComplete      the [AutoCompleteDefinition] for this option or `null` if no auto complete was defined
     /// @param validatorRegistry the corresponding [Validators]
     /// @return the [OptionDataDefinition]
     @NotNull
     public static OptionDataDefinition build(@NotNull ParameterDescription parameter,
-                                             boolean autoComplete,
+                                             @Nullable AutoCompleteDefinition autoComplete,
                                              @NotNull Validators validatorRegistry) {
         var optional = parameter.annotation(com.github.kaktushose.jda.commands.annotations.interactions.Optional.class);
         var defaultValue = "";
@@ -183,7 +184,7 @@ public record OptionDataDefinition(
 
         optionData.addChoices(choices);
         if (optionType.canSupportChoices() && choices.isEmpty()) {
-            optionData.setAutoComplete(autoComplete);
+            optionData.setAutoComplete(autoComplete != null);
         }
 
         constraints.stream().filter(constraint ->

--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/AutoCompleteHandler.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/AutoCompleteHandler.java
@@ -27,7 +27,8 @@ public final class AutoCompleteHandler extends EventHandler<CommandAutoCompleteI
         Optional<AutoCompleteDefinition> autoComplete;
 
         autoComplete = registry.find(AutoCompleteDefinition.class,
-                it -> it.commands().stream().anyMatch(name -> interaction.getFullCommandName().startsWith(name))
+                it -> it.commands().stream()
+                        .anyMatch(rule -> interaction.getFullCommandName().startsWith(rule.command()))
         ).stream().findFirst();
 
         if (autoComplete.isEmpty()) {
@@ -36,7 +37,8 @@ public final class AutoCompleteHandler extends EventHandler<CommandAutoCompleteI
             ).stream().findFirst();
             if (command.isPresent()) {
                 autoComplete = registry.find(AutoCompleteDefinition.class,
-                        it -> it.commands().stream().anyMatch(name -> command.get().methodDescription().name().equals(name))
+                        it -> it.commands().stream()
+                                .anyMatch(rule -> command.get().methodDescription().name().equals(rule.command()))
                 ).stream().findFirst();
             }
         }

--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/AutoCompleteHandler.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/AutoCompleteHandler.java
@@ -1,6 +1,6 @@
 package com.github.kaktushose.jda.commands.dispatching.handling;
 
-import com.github.kaktushose.jda.commands.definitions.interactions.AutoCompleteDefinition;
+import com.github.kaktushose.jda.commands.definitions.interactions.command.OptionDataDefinition;
 import com.github.kaktushose.jda.commands.definitions.interactions.command.SlashCommandDefinition;
 import com.github.kaktushose.jda.commands.dispatching.DispatchingContext;
 import com.github.kaktushose.jda.commands.dispatching.Runtime;
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.Optional;
 
 @ApiStatus.Internal
 public final class AutoCompleteHandler extends EventHandler<CommandAutoCompleteInteractionEvent> {
@@ -24,30 +23,28 @@ public final class AutoCompleteHandler extends EventHandler<CommandAutoCompleteI
     @Override
     protected InvocationContext<CommandAutoCompleteInteractionEvent> prepare(@NotNull CommandAutoCompleteInteractionEvent event, @NotNull Runtime runtime) {
         CommandAutoCompleteInteraction interaction = event.getInteraction();
-        Optional<AutoCompleteDefinition> autoComplete;
 
-        autoComplete = registry.find(AutoCompleteDefinition.class,
-                it -> it.commands().stream()
-                        .anyMatch(rule -> interaction.getFullCommandName().startsWith(rule.command()))
-        ).stream().findFirst();
-
-        if (autoComplete.isEmpty()) {
-            var command = registry.find(SlashCommandDefinition.class,
-                    it -> it.name().equals(interaction.getFullCommandName())
-            ).stream().findFirst();
-            if (command.isPresent()) {
-                autoComplete = registry.find(AutoCompleteDefinition.class,
-                        it -> it.commands().stream()
-                                .anyMatch(rule -> command.get().methodDescription().name().equals(rule.command()))
-                ).stream().findFirst();
-            }
-        }
-
-        return autoComplete.map(it ->
-                new InvocationContext<>(event, runtime.keyValueStore(), it, List.of(new AutoCompleteEvent(event, registry, runtime)))
-        ).orElseGet(() -> {
-            log.debug("No auto complete handler found for {}", interaction.getFullCommandName());
-            return null;
-        });
+        return registry.find(SlashCommandDefinition.class, it -> it.name().equals(interaction.getFullCommandName()))
+                .stream()
+                .findFirst()
+                .map(slashCommandDefinition -> slashCommandDefinition.commandOptions().stream()
+                        .filter(option -> option.name().equals(event.getFocusedOption().getName()))
+                        .findFirst()
+                        .map(OptionDataDefinition::autoComplete)
+                        .map(definition ->
+                                new InvocationContext<>(
+                                        event,
+                                        runtime.keyValueStore(),
+                                        definition,
+                                        List.of(new AutoCompleteEvent(event, registry, runtime))
+                                )
+                        ).orElseGet(() -> {
+                            log.debug("No auto complete handler found for command \"/{}\"", interaction.getFullCommandName());
+                            return null;
+                        })
+                ).orElseGet(() -> {
+                    log.debug("Received unknown command \"/{}\"", interaction.getFullCommandName());
+                    return null;
+                });
     }
 }

--- a/core/src/test/java/parameters/OptionDataDefinitionTest.java
+++ b/core/src/test/java/parameters/OptionDataDefinitionTest.java
@@ -43,7 +43,7 @@ public class OptionDataDefinitionTest {
     @Test
     public void optional_withoutDefault_ShouldBeNull() throws NoSuchMethodException {
         Method method = controller.getDeclaredMethod("optional", Object.class);
-        OptionDataDefinition parameter = OptionDataDefinition.build(parameter(method.getParameters()[0]), false, validatorRegistry);
+        OptionDataDefinition parameter = OptionDataDefinition.build(parameter(method.getParameters()[0]), null, validatorRegistry);
 
         assertTrue(parameter.optional());
         assertNull(parameter.defaultValue());
@@ -52,7 +52,7 @@ public class OptionDataDefinitionTest {
     @Test
     public void optional_withDefault_ShouldWork() throws NoSuchMethodException {
         Method method = controller.getDeclaredMethod("optionalWithDefault", Object.class);
-        OptionDataDefinition parameter = OptionDataDefinition.build(parameter(method.getParameters()[0]), false, validatorRegistry);
+        OptionDataDefinition parameter = OptionDataDefinition.build(parameter(method.getParameters()[0]), null, validatorRegistry);
 
         assertTrue(parameter.optional());
         assertEquals("default", parameter.defaultValue());
@@ -61,7 +61,7 @@ public class OptionDataDefinitionTest {
     @Test
     public void constraintMin_withLimit10_ShouldWork() throws NoSuchMethodException {
         Method method = controller.getDeclaredMethod("constraint", int.class);
-        OptionDataDefinition parameter = OptionDataDefinition.build(parameter(method.getParameters()[0]), false, validatorRegistry);
+        OptionDataDefinition parameter = OptionDataDefinition.build(parameter(method.getParameters()[0]), null, validatorRegistry);
 
         var constraints = List.copyOf(parameter.constraints());
         assertEquals(1, parameter.constraints().size());
@@ -73,7 +73,7 @@ public class OptionDataDefinitionTest {
     @Test
     public void constraintMin_withLimit10Wrapped_ShouldWork() throws NoSuchMethodException {
         Method method = controller.getDeclaredMethod("constraintWrapped", Integer.class);
-        OptionDataDefinition parameter = OptionDataDefinition.build(parameter(method.getParameters()[0]), false, validatorRegistry);
+        OptionDataDefinition parameter = OptionDataDefinition.build(parameter(method.getParameters()[0]), null, validatorRegistry);
 
         var constraints = List.copyOf(parameter.constraints());
         assertEquals(1, parameter.constraints().size());
@@ -85,7 +85,7 @@ public class OptionDataDefinitionTest {
     @Test
     public void constraint_withMessage_ShouldWork() throws NoSuchMethodException {
         Method method = controller.getDeclaredMethod("constraintWithMessage", int.class);
-        OptionDataDefinition parameter = OptionDataDefinition.build(parameter(method.getParameters()[0]), false, validatorRegistry);
+        OptionDataDefinition parameter = OptionDataDefinition.build(parameter(method.getParameters()[0]), null, validatorRegistry);
         var constraints = List.copyOf(parameter.constraints());
 
         assertEquals("error message", constraints.getFirst().message());


### PR DESCRIPTION
# Problem
Currently if a command has an auto complete handler *all* command options get registered with the auto complete flag. This is annoying because often you only have multiple command options, but only one of them needs auto complete. 

# Proposal
Enhance the atuo complete annotation to support filtering for specific options. In addition to the `value` field for the command reference, introduce an optional `options` field, where the user can specifiy command options the given auto complete handler is responsible for. One handler can handle multiple commands as well as multiple command options.

# Example
```java
@SlashCommand("favourite food")
public void foodCommand(CommandEvent event, String fruit, String vegetable) {
    event.reply("You've chosen: %s and %s", fruit, vegetable);
}

@AutoComplete(vale = "favourite food", options = "fruit")
public void onFruitAutoComplete(AutoCompleteEvent event) {
    event.replyChoices(...);
}
```