### PR TITLE
remove message create data reply method from ConfigurableReply

### DIFF
--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/context/InvocationContext.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/context/InvocationContext.java
@@ -2,7 +2,7 @@ package com.github.kaktushose.jda.commands.dispatching.context;
 
 import com.github.kaktushose.jda.commands.definitions.features.internal.Invokable;
 import com.github.kaktushose.jda.commands.definitions.interactions.InteractionDefinition;
-import com.github.kaktushose.jda.commands.dispatching.reply.MessageReply;
+import com.github.kaktushose.jda.commands.dispatching.reply.internal.MessageCreateDataReply;
 import com.github.kaktushose.jda.commands.embeds.error.ErrorMessageFactory.ErrorContext;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
@@ -28,7 +28,7 @@ public record InvocationContext<T extends GenericInteractionCreateEvent>(
     /// @param errorMessage the error message that should be sent to the user as a reply
     /// @implNote This will interrupt the current event thread
     public void cancel(@NotNull MessageCreateData errorMessage) {
-        new MessageReply(event, definition, new InteractionDefinition.ReplyConfig()).reply(errorMessage);
+        MessageCreateDataReply.reply(event, definition, new InteractionDefinition.ReplyConfig(), errorMessage);
 
         Thread.currentThread().interrupt();
     }

--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/events/ReplyableEvent.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/events/ReplyableEvent.java
@@ -15,6 +15,7 @@ import com.github.kaktushose.jda.commands.dispatching.events.interactions.ModalE
 import com.github.kaktushose.jda.commands.dispatching.reply.ConfigurableReply;
 import com.github.kaktushose.jda.commands.dispatching.reply.MessageReply;
 import com.github.kaktushose.jda.commands.dispatching.reply.Reply;
+import com.github.kaktushose.jda.commands.dispatching.reply.internal.MessageCreateDataReply;
 import com.github.kaktushose.jda.commands.internal.Helpers;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
@@ -23,6 +24,7 @@ import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.interactions.components.ActionComponent;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
+import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -152,13 +154,21 @@ public sealed abstract class ReplyableEvent<T extends GenericInteractionCreateEv
         return new ConfigurableReply(newReply(), registry, runtimeId());
     }
 
-    @NotNull
-    public Message reply(@NotNull String message) {
-        return newReply().reply(message);
+    /// Acknowledgement of this event with a text message.
+    ///
+    /// @param message the [MessageCreateData] to send
+    /// @return the [Message] that got created
+    /// @implSpec Internally this method must call [RestAction#complete()], thus the [Message] object can get
+    /// returned directly.
+    ///
+    /// This might throw [RuntimeException]s if JDA fails to send the message.
+    public Message reply(@NotNull MessageCreateData message) {
+        log.debug("Reply Debug: Replying only with MessageCreateData. [Runtime={}]", runtimeId());
+        return MessageCreateDataReply.reply(event, definition, replyConfig, message);
     }
 
     @NotNull
-    public Message reply(@NotNull MessageCreateData message) {
+    public Message reply(@NotNull String message) {
         return newReply().reply(message);
     }
 

--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/command/SlashCommandHandler.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/command/SlashCommandHandler.java
@@ -8,7 +8,7 @@ import com.github.kaktushose.jda.commands.dispatching.adapter.internal.TypeAdapt
 import com.github.kaktushose.jda.commands.dispatching.context.InvocationContext;
 import com.github.kaktushose.jda.commands.dispatching.events.interactions.CommandEvent;
 import com.github.kaktushose.jda.commands.dispatching.handling.EventHandler;
-import com.github.kaktushose.jda.commands.dispatching.reply.MessageReply;
+import com.github.kaktushose.jda.commands.dispatching.reply.internal.MessageCreateDataReply;
 import com.github.kaktushose.jda.commands.internal.Helpers;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -93,7 +93,7 @@ public final class SlashCommandHandler extends EventHandler<SlashCommandInteract
 
             if (parsed.isEmpty()) {
                 log.debug("Type adapting failed!");
-                new MessageReply(event, command, dispatchingContext.globalReplyConfig()).reply(
+                MessageCreateDataReply.reply(event, command, dispatchingContext.globalReplyConfig(),
                         errorMessageFactory.getTypeAdaptingFailedMessage(Helpers.errorContext(event, command), input
                                 .stream()
                                 .map(it -> it == null ? null : it.getAsString())

--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/reply/MessageReply.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/reply/MessageReply.java
@@ -2,13 +2,13 @@ package com.github.kaktushose.jda.commands.dispatching.reply;
 
 import com.github.kaktushose.jda.commands.definitions.interactions.InteractionDefinition;
 import com.github.kaktushose.jda.commands.dispatching.events.ReplyableEvent;
+import com.github.kaktushose.jda.commands.dispatching.reply.internal.MessageCreateDataReply;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Mentions;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.EntitySelectInteractionEvent;
-import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.callbacks.IDeferrableCallback;
@@ -43,7 +43,7 @@ import java.util.List;
 ///
 /// @see ConfigurableReply
 /// @see ReplyableEvent
-public sealed class MessageReply implements Reply permits ConfigurableReply {
+public sealed class MessageReply implements Reply permits ConfigurableReply, MessageCreateDataReply {
 
     protected static final Logger log = LoggerFactory.getLogger(MessageReply.class);
     protected final GenericInteractionCreateEvent event;
@@ -86,11 +86,6 @@ public sealed class MessageReply implements Reply permits ConfigurableReply {
 
     public Message reply(@NotNull String message) {
         builder.setContent(message);
-        return complete();
-    }
-
-    public Message reply(@NotNull MessageCreateData message) {
-        builder.applyData(message);
         return complete();
     }
 

--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/reply/Reply.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/reply/Reply.java
@@ -6,7 +6,6 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.requests.RestAction;
-import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.jetbrains.annotations.NotNull;
 
 /// Common interface for classes that support simple message replies to [GenericInteractionCreateEvent].
@@ -42,16 +41,6 @@ public sealed interface Reply permits MessageReply, ReplyableEvent {
     default Message reply(@NotNull String format, @NotNull Object... args) {
         return reply(format.formatted(args));
     }
-
-    /// Acknowledgement of this event with a text message.
-    ///
-    /// @param message the [MessageCreateData] to send
-    /// @return the [Message] that got created
-    /// @implSpec Internally this method must call [RestAction#complete()], thus the [Message] object can get
-    /// returned directly.
-    ///
-    /// This might throw [RuntimeException]s if JDA fails to send the message.
-    Message reply(@NotNull MessageCreateData message);
 
     /// Acknowledgement of this event with a text message.
     ///

--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/reply/internal/MessageCreateDataReply.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/reply/internal/MessageCreateDataReply.java
@@ -1,0 +1,31 @@
+package com.github.kaktushose.jda.commands.dispatching.reply.internal;
+
+import com.github.kaktushose.jda.commands.definitions.interactions.InteractionDefinition;
+import com.github.kaktushose.jda.commands.dispatching.reply.MessageReply;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import org.jetbrains.annotations.NotNull;
+
+public final class MessageCreateDataReply extends MessageReply {
+
+    private MessageCreateDataReply(@NotNull GenericInteractionCreateEvent event,
+                                   @NotNull InteractionDefinition definition,
+                                   @NotNull InteractionDefinition.ReplyConfig replyConfig,
+                                   @NotNull MessageCreateData data) {
+        super(event, definition, replyConfig);
+        builder.applyData(data);
+    }
+
+    public static Message reply(@NotNull GenericInteractionCreateEvent event,
+                                @NotNull InteractionDefinition definition,
+                                @NotNull InteractionDefinition.ReplyConfig replyConfig,
+                                @NotNull MessageCreateData data) {
+        return new MessageCreateDataReply(event, definition, replyConfig, data).completeInternal();
+    }
+
+    private Message completeInternal() {
+        return complete();
+    }
+
+}


### PR DESCRIPTION
Removes the `reply(MessageCreateData message)` method from `ConfigurableReply` (and `ComponentReply`) because it leads to confusing behaviour, since the `MessageCreateData` also overrides components. 

This method is no only available in the `ReplyEvent`.