### PR TITLE
Add support for Member in user context command

### DIFF
--- a/core/src/main/java/com/github/kaktushose/jda/commands/annotations/interactions/Command.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/annotations/interactions/Command.java
@@ -2,8 +2,10 @@ package com.github.kaktushose.jda.commands.annotations.interactions;
 
 import com.github.kaktushose.jda.commands.dispatching.adapter.internal.TypeAdapters;
 import com.github.kaktushose.jda.commands.dispatching.events.interactions.CommandEvent;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.interactions.InteractionContextType;
 import net.dv8tion.jda.api.interactions.commands.Command.Type;
 
 import java.lang.annotation.ElementType;
@@ -49,7 +51,7 @@ import java.util.Optional;
 /// The method signature has to meet the following conditions:
 ///
 ///   - First parameter must be of type [CommandEvent]
-///   - Second parameter must either be a [User] or a [Message]
+///   - Second parameter must either be a [User], [Member] or a [Message]
 ///
 /// ## Examples:
 /// ```
@@ -58,7 +60,11 @@ import java.util.Optional;
 ///
 /// @Command(value = "user context command", type = Type.USER)
 /// public void onCommand(CommandEvent event, User target) { ... }
+///
+/// @Command(value = "member context command", type = Type.USER)
+/// public void onCommand(CommandEvent event, Member target) { ... }
 /// ```
+/// **Using [Member] will enforce [InteractionContextType#GUILD] on the command!**
 /// @see Interaction
 /// @see com.github.kaktushose.jda.commands.annotations.interactions.Interaction Interaction
 /// @see com.github.kaktushose.jda.commands.annotations.constraints.Constraint Constraint

--- a/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/command/ContextCommandDefinition.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/command/ContextCommandDefinition.java
@@ -69,16 +69,22 @@ public record ContextCommandDefinition(
     public CommandData toJDAEntity() {
         var command = Commands.context(commandType, name);
         // enforce guild context if user context command has member
-        if (methodDescription.parameters().getLast().type().equals(Member.class)) {
-            command.setContexts(InteractionContextType.GUILD);
-        } else {
-            command.setContexts(commandConfig.context());
+        if (methodDescription.parameters().getLast().type().equals(Member.class) && isInvalidContext(commandConfig.context())) {
+            throw new InvalidDeclarationException("member-context-guild");
         }
+        command.setContexts(commandConfig.context());
         command.setIntegrationTypes(commandConfig.integration())
                 .setNSFW(commandConfig.isNSFW())
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(commandConfig.enabledPermissions()))
                 .setLocalizationFunction(localizationFunction);
         return command;
+    }
+
+    private boolean isInvalidContext(InteractionContextType[] types) {
+        if (types.length != 1) {
+            return true;
+        }
+        return types[0] != InteractionContextType.GUILD;
     }
 
     @Override

--- a/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/command/ContextCommandDefinition.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/command/ContextCommandDefinition.java
@@ -6,8 +6,9 @@ import com.github.kaktushose.jda.commands.definitions.interactions.MethodBuildCo
 import com.github.kaktushose.jda.commands.dispatching.events.interactions.CommandEvent;
 import com.github.kaktushose.jda.commands.exceptions.InvalidDeclarationException;
 import com.github.kaktushose.jda.commands.internal.Helpers;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.interactions.InteractionContextType;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
@@ -44,16 +45,11 @@ public record ContextCommandDefinition(
         var method = context.method();
         var command = method.annotation(com.github.kaktushose.jda.commands.annotations.interactions.Command.class).orElseThrow();
 
-        var type = switch (command.type()) {
-            case USER -> User.class;
-            case MESSAGE -> Message.class;
-            default -> null;
-        };
-        if (type == null) {
-            throw new InvalidDeclarationException("invalid-context-command-type");
+        switch (command.type()) {
+            case USER -> Helpers.checkSignatureUserContext(method);
+            case MESSAGE -> Helpers.checkSignature(method, List.of(CommandEvent.class, Message.class));
+            default ->  throw new InvalidDeclarationException("invalid-context-command-type");
         }
-
-        Helpers.checkSignature(method, List.of(CommandEvent.class, type));
 
         return new ContextCommandDefinition(
                 context.clazz(),
@@ -72,8 +68,13 @@ public record ContextCommandDefinition(
     @Override
     public CommandData toJDAEntity() {
         var command = Commands.context(commandType, name);
+        // enforce guild context if user context command has member
+        if (methodDescription.parameters().getLast().type().equals(Member.class)) {
+            command.setContexts(InteractionContextType.GUILD);
+        } else {
+            command.setContexts(commandConfig.context());
+        }
         command.setIntegrationTypes(commandConfig.integration())
-                .setContexts(commandConfig.context())
                 .setNSFW(commandConfig.isNSFW())
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(commandConfig.enabledPermissions()))
                 .setLocalizationFunction(localizationFunction);

--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/command/ContextCommandHandler.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/command/ContextCommandHandler.java
@@ -8,8 +8,10 @@ import com.github.kaktushose.jda.commands.dispatching.Runtime;
 import com.github.kaktushose.jda.commands.dispatching.context.InvocationContext;
 import com.github.kaktushose.jda.commands.dispatching.events.interactions.CommandEvent;
 import com.github.kaktushose.jda.commands.dispatching.handling.EventHandler;
+import com.github.kaktushose.jda.commands.exceptions.InternalException;
 import com.github.kaktushose.jda.commands.internal.Helpers;
 import net.dv8tion.jda.api.events.interaction.command.GenericContextInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
@@ -29,8 +31,16 @@ public final class ContextCommandHandler extends EventHandler<GenericContextInte
 
         InteractionDefinition.ReplyConfig replyConfig = Helpers.replyConfig(command, dispatchingContext.globalReplyConfig());
 
+        Object target = event.getTarget();
+        if (event instanceof UserContextInteractionEvent userEvent) {
+            target = userEvent.getTargetMember();
+            if (target == null) {
+                throw new InternalException("null-member-context-command");
+            }
+        }
+
         return new InvocationContext<>(event, runtime.i18n(), runtime.keyValueStore(), command, replyConfig,
-                List.of(new CommandEvent(event, registry, runtime, command, replyConfig, dispatchingContext.embeds()), event.getTarget())
+                List.of(new CommandEvent(event, registry, runtime, command, replyConfig, dispatchingContext.embeds()), target)
         );
     }
 }

--- a/core/src/main/java/com/github/kaktushose/jda/commands/internal/Helpers.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/internal/Helpers.java
@@ -11,11 +11,13 @@ import com.github.kaktushose.jda.commands.definitions.features.internal.Invokabl
 import com.github.kaktushose.jda.commands.definitions.interactions.InteractionDefinition;
 import com.github.kaktushose.jda.commands.definitions.interactions.MethodBuildContext;
 import com.github.kaktushose.jda.commands.definitions.interactions.command.CommandDefinition;
+import com.github.kaktushose.jda.commands.dispatching.events.interactions.CommandEvent;
 import com.github.kaktushose.jda.commands.embeds.error.ErrorMessageFactory.ErrorContext;
 import com.github.kaktushose.jda.commands.exceptions.InternalException;
 import com.github.kaktushose.jda.commands.exceptions.InvalidDeclarationException;
 import com.github.kaktushose.jda.commands.exceptions.internal.JDACException;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.detached.IDetachableEntity;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -103,6 +105,24 @@ public final class Helpers {
                     entry("prefix", prefix),
                     entry("expected", methodSignature.stream().toList()),
                     entry("actual", method.parameters().stream().map(ParameterDescription::type).toList())
+            );
+        }
+    }
+
+    public static void checkSignatureUserContext(MethodDescription method) {
+        var parameters = method.parameters().stream()
+                .map(ParameterDescription::type)
+                .toList();
+        if (!(parameters.equals(List.of(CommandEvent.class, User.class)) || parameters.equals(List.of(CommandEvent.class, Member.class)))) {
+
+            String prefix = !parameters.isEmpty() && parameters.getFirst().equals(CommandEvent.class)
+                    ? ""
+                    : " You forgot to add \"%s\" as the first parameter of the method. ".formatted(CommandEvent.class);
+
+            throw new InvalidDeclarationException("incorrect-method-signature",
+                    entry("prefix", prefix),
+                    entry("expected", "[%s, %s OR %s]".formatted(CommandEvent.class, User.class, Member.class)),
+                    entry("actual", method.parameters().stream().map(ParameterDescription::type).toList().toString())
             );
         }
     }

--- a/core/src/main/java/com/github/kaktushose/jda/commands/internal/Helpers.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/internal/Helpers.java
@@ -22,8 +22,6 @@ import net.dv8tion.jda.api.entities.detached.IDetachableEntity;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import org.jetbrains.annotations.ApiStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -35,8 +33,6 @@ import static com.github.kaktushose.jda.commands.i18n.I18n.entry;
 /// Collection of helper methods that are used inside the framework.
 @ApiStatus.Internal
 public final class Helpers {
-
-    private static final Logger log = LoggerFactory.getLogger(Helpers.class);
 
     /// Gets the human-readable representation of an [OptionMapping].
     ///
@@ -99,7 +95,7 @@ public final class Helpers {
 
             String prefix = !parameters.isEmpty() && parameters.getFirst().equals(methodSignature.getFirst())
                     ? ""
-                    : " You forgot to add \"%s\" as the first parameter of the method. ".formatted(methodSignature.getFirst());
+                    : JDACException.errorMessage("incorrect-method-signature", entry("parameter", methodSignature.getFirst().getName()));
 
             throw new InvalidDeclarationException("incorrect-method-signature",
                     entry("prefix", prefix),
@@ -117,7 +113,7 @@ public final class Helpers {
 
             String prefix = !parameters.isEmpty() && parameters.getFirst().equals(CommandEvent.class)
                     ? ""
-                    : " You forgot to add \"%s\" as the first parameter of the method. ".formatted(CommandEvent.class);
+                    : JDACException.errorMessage("incorrect-method-signature", entry("parameter", CommandEvent.class.getName()));
 
             throw new InvalidDeclarationException("incorrect-method-signature",
                     entry("prefix", prefix),

--- a/core/src/main/resources/jdac_en.ftl
+++ b/core/src/main/resources/jdac_en.ftl
@@ -53,6 +53,9 @@ incorrect-method-signature =
     { $prefix }Invalid method signature.
         Expected: { $expected }
         Actual: { $actual }
+incorrect-method-signature-hint = You forgot to add { $parameter } as the first parameter of the method.
+member-context-guild = User context commands which use a Member object are only allowed to use InteractionContextType.GUILD.
+    Change the InteractionContextType or use an User object instead.
 
 # Configuration Errors
 resource-not-found = Failed to find resource "{ $resource }".

--- a/core/src/main/resources/jdac_en.ftl
+++ b/core/src/main/resources/jdac_en.ftl
@@ -26,6 +26,7 @@ wrong-labels = Failed to add child command: { $command }. { $labelCount ->
         *[other] Cannot add a child with more than { $labelCount } labels.
     }
 subcommand-with-children = Cannot transform node with children to SubcommandData.
+null-member-context-command = Member for context command is null (not executed in a guild). This should not be possible.
 
 # Invalid Declaration
 blank-name = Command name must be not blank.


### PR DESCRIPTION
In user context commands we can get a member object via [`UserContextInteractionEvent#getTargetMember()` ](https://docs.jda.wiki/net/dv8tion/jda/api/events/interaction/command/UserContextInteractionEvent.html#getTargetMember()). Currently we throw that information away and enforce the usage of User. If the user needs a Member object, he has to retrieve it again:
```java
@Command(value = "Ping User", type = Type.USER)
public void onCommand(CommandEvent event, User user) {
    member = event.jdaEvent().retrieveMemberById(user.getIdLong()).complete();
}
```
With this pr, users can also add a Member to the method signature. Internally this will enforce `InteractionContextType.GUILD` for the command to ensure that we can always get a member object. 
```java
@Command(value = "Ping User", type = Type.USER)
public void onCommand(CommandEvent event, Member member) {
    
}
```

closes #220 