### PR TITLE
Replaces # with $ for bundle name separation and adds escaping mechanism

### DIFF
--- a/core/src/main/java/com/github/kaktushose/jda/commands/i18n/I18n.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/i18n/I18n.java
@@ -20,12 +20,20 @@ import java.util.*;
 /// To state which bundle to use the direct way is to include it in the key following the format `bundle$key`.
 /// For example a message with key `user$not-found` will be searched for in the bundle `user` and the key `not-found`.
 ///
-/// Please note, that the dollar (`$`) is a reserved character for bundle name separation.
-/// If you have to use `$` in the message key or
-/// any string that goes through localization (technically most strings written in annotations) just prefix the message
-/// with the dollar sign. For example, the message `$My message that needs the $ in there` will be displayed as
-/// `My message that needs the $ in there`.
+/// ### dollar sign
+/// The dollar (`$`) is a reserved character for [bundle name separation](#bundles).
 ///
+/// Practically, in all cases this doesn't really bother, there are only 2 niche situations where the dollar has to be escaped:
+///   - your message key contains `$` and no bundle is explicitly stated, e.g. `key.with$.in.it`
+///   - the string is a directly inserted localization messages that happens to have it's prior `$` part to match a bundle name and is later to match a message key, e.g.
+///     - you have a bundle called `my_bundle`
+///     - you have a message key called `my-key` in that bundle
+///     - and you want to print the message `my_bundle$my-key` to the user
+///
+/// In these cases just prefix your whole message with a `$`, e.g. `$my_bundle$my-key` or `$key.with$.in.it`.
+/// Now the bundle will be treated as not stated explicitly and the dollar sign will be preserved.
+///
+/// ## bundle name traversal
 /// If no bundle is specified, it will traverse the stack (the called methods) and search for the nearest
 /// [`@Bundle("mybundle")`](Bundle) annotation with following order:
 ///

--- a/core/src/main/java/com/github/kaktushose/jda/commands/i18n/I18n.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/i18n/I18n.java
@@ -5,6 +5,7 @@ import com.github.kaktushose.jda.commands.definitions.description.ClassDescripti
 import com.github.kaktushose.jda.commands.definitions.description.Description;
 import com.github.kaktushose.jda.commands.definitions.description.Descriptor;
 import com.github.kaktushose.jda.commands.i18n.internal.JDACLocalizationFunction;
+import dev.goldmensch.fluava.Fluava;
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFunction;
 import org.apache.commons.collections4.map.LRUMap;
 import org.jspecify.annotations.Nullable;
@@ -18,6 +19,12 @@ import java.util.*;
 ///
 /// To state which bundle to use the direct way is to include it in the key following the format `bundle$key`.
 /// For example a message with key `user$not-found` will be searched for in the bundle `user` and the key `not-found`.
+///
+/// Please note, that the dollar (`$`) is a reserved character for bundle name separation.
+/// If you have to use `$` in the message key or
+/// any string that goes through localization (technically most strings written in annotations) just prefix the message
+/// with the dollar sign. For example, the message `$My message that needs the $ in there` will be displayed as
+/// `My message that needs the $ in there`.
 ///
 /// If no bundle is specified, it will traverse the stack (the called methods) and search for the nearest
 /// [`@Bundle("mybundle")`](Bundle) annotation with following order:
@@ -123,6 +130,8 @@ public class I18n {
     /// key in the following format: `bundle$key`. Alternatively, the bundle name can also be
     /// contextual retrieved by a search for the [Bundle] annotation, see class docs.
     ///
+    /// Please note that the character `$` is forbidden in bundle names.
+    ///
     /// @param locale the [Locale] to be used to localize the key
     /// @param combinedKey the messages key
     /// @param placeholder the placeholder to be used
@@ -130,7 +139,7 @@ public class I18n {
     /// @return the localized message or the key if not found
     public String localize(Locale locale, String combinedKey, Map<String, @Nullable Object> placeholder) {
         String[] bundleSplit = combinedKey.split("\\$", 2);
-        String bundle = bundleSplit.length == 2
+        String bundle = bundleSplit.length == 2 && !bundleSplit[0].isEmpty()
                 ? bundleSplit[0].trim()
                 : findBundle();
 
@@ -141,6 +150,12 @@ public class I18n {
         return localizer.localize(locale, bundle, key, placeholder)
                 .or(() -> localizer.localizeMessage(locale, combinedKey, placeholder))
                 .orElse(combinedKey);
+    }
+
+    public static void main(String[] args) {
+        I18n i18n = new I18n(Descriptor.REFLECTIVE, new FluavaLocalizer(new Fluava(Locale.ENGLISH, Map.of())));
+        String localized = i18n.localize(Locale.ENGLISH, "key$huhu");
+        System.out.println(localized);
     }
 
     /// This method returns the localized message found by the provided [Locale] and key

--- a/core/src/main/java/com/github/kaktushose/jda/commands/i18n/I18n.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/i18n/I18n.java
@@ -5,7 +5,6 @@ import com.github.kaktushose.jda.commands.definitions.description.ClassDescripti
 import com.github.kaktushose.jda.commands.definitions.description.Description;
 import com.github.kaktushose.jda.commands.definitions.description.Descriptor;
 import com.github.kaktushose.jda.commands.i18n.internal.JDACLocalizationFunction;
-import dev.goldmensch.fluava.Fluava;
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFunction;
 import org.apache.commons.collections4.map.LRUMap;
 import org.jspecify.annotations.Nullable;
@@ -25,10 +24,10 @@ import java.util.*;
 ///
 /// Practically, in all cases this doesn't really bother, there are only 2 niche situations where the dollar has to be escaped:
 ///   - your message key contains `$` and no bundle is explicitly stated, e.g. `key.with$.in.it`
-///   - the string is a directly inserted localization messages that happens to have it's prior `$` part to match a bundle name and is later to match a message key, e.g.
+///   - the string is a directly inserted localization messages containing `$`, that happens to have it's prior `$` part to match a bundle name and its after `$` part to match a message key, e.g.
 ///     - you have a bundle called `my_bundle`
 ///     - you have a message key called `my-key` in that bundle
-///     - and you want to print the message `my_bundle$my-key` to the user
+///     - and you want to print the message `my_bundle$my-key` to the user (not the message stored under "my-key" in the bundle "my_bundle")
 ///
 /// In these cases just prefix your whole message with a `$`, e.g. `$my_bundle$my-key` or `$key.with$.in.it`.
 /// Now the bundle will be treated as not stated explicitly and the dollar sign will be preserved.
@@ -158,12 +157,6 @@ public class I18n {
         return localizer.localize(locale, bundle, key, placeholder)
                 .or(() -> localizer.localizeMessage(locale, combinedKey, placeholder))
                 .orElse(combinedKey);
-    }
-
-    public static void main(String[] args) {
-        I18n i18n = new I18n(Descriptor.REFLECTIVE, new FluavaLocalizer(new Fluava(Locale.ENGLISH, Map.of())));
-        String localized = i18n.localize(Locale.ENGLISH, "key$huhu");
-        System.out.println(localized);
     }
 
     /// This method returns the localized message found by the provided [Locale] and key

--- a/core/src/main/java/com/github/kaktushose/jda/commands/i18n/I18n.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/i18n/I18n.java
@@ -16,11 +16,12 @@ import java.util.*;
 ///
 /// It is mostly a wrapper around [Localizer] but supports flexible specification of the bundle to be used.
 ///
-/// To state which bundle to use the direct way is to include it in the key following the format `bundle#key`.
-/// For example a message with key `user#not-found` will be searched for in the bundle `user` and the key `not-found`.
+/// To state which bundle to use the direct way is to include it in the key following the format `bundle$key`.
+/// For example a message with key `user$not-found` will be searched for in the bundle `user` and the key `not-found`.
 ///
 /// If no bundle is specified, it will traverse the stack (the called methods) and search for the nearest
 /// [`@Bundle("mybundle")`](Bundle) annotation with following order:
+///
 ///
 /// 1. method that called [I18n#localize(Locale, String, Entry...)]
 /// 2. other called methods in the same class
@@ -75,17 +76,17 @@ import java.util.*;
 /// ```
 ///
 /// The order in which the bundle name is searched for is following:
-/// 1. method `A#aOne()`
-/// 2. method `A#aTwo()`
+/// 1. method `A$aOne()`
+/// 2. method `A$aTwo()`
 /// 3. class `A`
 /// 4. `package-info.java` of package `my.app`
-/// 5. method `B#bOne()`
-/// 6. method `B#two()`
+/// 5. method `B$bOne()`
+/// 6. method `B$two()`
 ///
 /// The found bundle would be `pack_bundle`.
 ///
 /// If [I18n#localize(java.util.Locale, java.lang.String, com.github.kaktushose.jda.commands.i18n.I18n.Entry...)]
-/// would be called in, for example, `B#bTwo` the bundle would be `mB_bundle`.
+/// would be called in, for example, `B$bTwo` the bundle would be `mB_bundle`.
 public class I18n {
 
     // skipped classes during stack scanning (Class.getName().startWith(X))
@@ -119,7 +120,7 @@ public class I18n {
     /// in the given bundle.
     ///
     /// The bundle can be either explicitly stated by adding it to the
-    /// key in the following format: `bundle#key`. Alternatively, the bundle name can also be
+    /// key in the following format: `bundle$key`. Alternatively, the bundle name can also be
     /// contextual retrieved by a search for the [Bundle] annotation, see class docs.
     ///
     /// @param locale the [Locale] to be used to localize the key
@@ -128,7 +129,7 @@ public class I18n {
     ///
     /// @return the localized message or the key if not found
     public String localize(Locale locale, String combinedKey, Map<String, @Nullable Object> placeholder) {
-        String[] bundleSplit = combinedKey.split("#", 2);
+        String[] bundleSplit = combinedKey.split("\\$", 2);
         String bundle = bundleSplit.length == 2
                 ? bundleSplit[0].trim()
                 : findBundle();
@@ -146,7 +147,7 @@ public class I18n {
     /// in the given bundle.
     ///
     /// The bundle can be either explicitly stated by adding it to the
-    /// key in the following format: `bundle#key`. Alternatively, the bundle name can also be
+    /// key in the following format: `bundle$key`. Alternatively, the bundle name can also be
     /// contextual retrieved by a search for the [Bundle] annotation, see class docs.
     ///
     /// @param locale      the [Locale] to be used to localize the key

--- a/core/src/main/resources/key_en.ftl
+++ b/core/src/main/resources/key_en.ftl
@@ -1,0 +1,1 @@
+huhu = works

--- a/core/src/main/resources/key_en.ftl
+++ b/core/src/main/resources/key_en.ftl
@@ -1,1 +1,0 @@
-huhu = works

--- a/wiki/docs/interactions/components.md
+++ b/wiki/docs/interactions/components.md
@@ -16,6 +16,11 @@ as retrieved by a key. For more information on how to use the localization syste
     public void onButton(ComponentEvent event) {...}
     ```
 
+!!! warning The dollar sign ($)
+    The dollar sign is a reserved character for bundle name separation.
+    In most cases that shouldn't bother you but if you encounter any problems,
+    please read the notes [here](../localization.md#the-dollar--character).
+
 ## Buttons
 Buttons are defined by annotating a method with [`@Button`](https://kaktushose.github.io/jda-commands/javadocs/4/io.github.kaktushose.jda.commands.core/com/github/kaktushose/jda/commands/annotations/interactions/Button.html). 
 The first parameter must always be a [`ComponentEvent`](https://kaktushose.github.io/jda-commands/javadocs/4/io.github.kaktushose.jda.commands.core/com/github/kaktushose/jda/commands/dispatching/events/interactions/ComponentEvent.html).

--- a/wiki/docs/localization.md
+++ b/wiki/docs/localization.md
@@ -11,13 +11,13 @@ If a certain message for a key isn't found, the key is returned as the messages 
 ### The dollar ($) character
 The dollar (`$`) is a reserved character for [bundle name separation](#bundles).
 
-Practically, in all cases this doesn't really bother, there are only 2 niche situations where the dollar has to be escaped:
-- your message key contains `$` and no bundle is explicitly stated, e.g. `key.with$.in.it`
-- the string is a [directly inserted localization messages](#directly-inserting-localization-messages) 
-  that happens to have it's prior `$` part to match a bundle name and is later to match a message key, e.g.
+In practically all cases this doesn't really bother you, because there are only 2 niche situations where the dollar has to be escaped:
+- your message key contains `$` and no bundle is explicitly stated, e.g. `key.with$.in.it` (the default bundle should be used here)
+- the string is a [directly inserted localization messages](#directly-inserting-localization-messages) containing `$`,
+  that happens to have it's prior `$` part to match a bundle name and its after `$` part to match a message key, e.g.
   - you have a bundle called `my_bundle`
   - you have a message key called `my-key` in that bundle
-  - and you want to print the message `my_bundle$my-key` to the user
+  - and you want to print the message `my_bundle$my-key` to the user (not the message stored under "my-key" in the bundle "my_bundle")
 
 In these cases just prefix your whole message with a `$`, e.g. `$my_bundle$my-key` or `$key.with$.in.it`.
 Now the bundle will be treated as not stated explicitly and the dollar sign will be preserved.
@@ -69,7 +69,6 @@ A String value (whether in an annotation, embed, modal or component) will be res
 3. used as raw value
 
 An example of this can be found [here](#example-fluava).
-
 
 ## Variables/Placeholders
 Most localization systems support variables or placeholders to insert dynamic values into a message.

--- a/wiki/docs/localization.md
+++ b/wiki/docs/localization.md
@@ -94,8 +94,8 @@ localization files by adding them to the localization key or using the [`@Bundle
 annotation.
 
 ### Via Key
-To state which bundle to use the direct way is to include it in the key following the format `bundle#key`.
-For example a message with key `user#not-found` will be searched for in the bundle `user` and the key `not-found`.
+To state which bundle to use the direct way is to include it in the key following the format `bundle$key`.
+For example a message with key `user$not-found` will be searched for in the bundle `user` and the key `not-found`.
 
 ### Via Annotation
 
@@ -149,15 +149,15 @@ class at the very beginning.
 
     The order in which the bundle name is searched for is following:
 
-    1. method `A#aOne()`
-    2. method `A#aTwo()`
+    1. method `A$aOne()`
+    2. method `A$aTwo()`
     3. class `A`
     4. `package-info.java` of package `my.app`
-    5. method `B#bOne()`
-    6. method `B#bTwo()`
+    5. method `B$bOne()`
+    6. method `B$bTwo()`
 
     The found bundle would be `package_bundle`. If `I18n#localize(Locale, String, I18n.Entry...)`
-    would be called in, for example, `B#bTwo` the bundle would be `method_bundle`.
+    would be called in, for example, `B$bTwo` the bundle would be `method_bundle`.
 
 ### Default Bundle
 If no bundle is found with the above techniques, a bundle called `default` will be used.

--- a/wiki/docs/localization.md
+++ b/wiki/docs/localization.md
@@ -8,6 +8,20 @@ the restrictions of the used [`Localizer`](https://kaktushose.github.io/jda-comm
 
 If a certain message for a key isn't found, the key is returned as the messages value.
 
+### The dollar ($) character
+The dollar (`$`) is a reserved character for [bundle name separation](#bundles).
+
+Practically, in all cases this doesn't really bother, there are only 2 niche situations where the dollar has to be escaped:
+- your message key contains `$` and no bundle is explicitly stated, e.g. `key.with$.in.it`
+- the string is a [directly inserted localization messages](#directly-inserting-localization-messages) 
+  that happens to have it's prior `$` part to match a bundle name and is later to match a message key, e.g.
+  - you have a bundle called `my_bundle`
+  - you have a message key called `my-key` in that bundle
+  - and you want to print the message `my_bundle$my-key` to the user
+
+In these cases just prefix your whole message with a `$`, e.g. `$my_bundle$my-key` or `$key.with$.in.it`.
+Now the bundle will be treated as not stated explicitly and the dollar sign will be preserved.
+
 ## Implicit Localization
 Instead of using the localization API manually through the `I18n` class, JDA-Commands allows for implicit usage of
 localization keys in many common places. These include:
@@ -92,6 +106,9 @@ public class ComponentTest {
 Localization bundles are a known concept from Javas [ResourceBundles](https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/util/ResourceBundle.html). JDA-Commands supports different bundles of
 localization files by adding them to the localization key or using the [`@Bundle("bundle_name")`](https://kaktushose.github.io/jda-commands/javadocs/4/io.github.kaktushose.jda.commands.core/com/github/kaktushose/jda/commands/annotations/i18n/Bundle.html)
 annotation.
+
+!!! warning the dollar sign ($)
+    Please note that the character `$` is forbidden in bundle names.
 
 ### Via Key
 To state which bundle to use the direct way is to include it in the key following the format `bundle$key`.


### PR DESCRIPTION
This PR replaces the # used for bundle name separation with $ as the new separator. This should avoid any problems with discord's special treatment of some characters. It also adds a new niche escaping mechanism for that character.

closes #233 