### PR TITLE
Replace thread locals with scoped values

### DIFF
--- a/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/InteractionRegistry.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/InteractionRegistry.java
@@ -147,15 +147,14 @@ public record InteractionRegistry(Validators validators,
 
 
             // to be replaced with scoped values
-            InvalidDeclarationException.CONTEXT.set(method);
-            Definition definition = construct(method, context);
+            ScopedValue.where(InvalidDeclarationException.CONTEXT, method).run(() -> {
+                Definition definition = construct(method, context);
 
-            if (definition != null) {
-                log.debug("Found interaction: {}", definition);
-                definitions.add(definition);
-            }
-
-            InvalidDeclarationException.CONTEXT.remove();
+                if (definition != null) {
+                    log.debug("Found interaction: {}", definition);
+                    definitions.add(definition);
+                }
+            });
         }
         return definitions;
     }

--- a/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/InteractionRegistry.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/definitions/interactions/InteractionRegistry.java
@@ -146,7 +146,6 @@ public record InteractionRegistry(Validators validators,
             );
 
 
-            // to be replaced with scoped values
             ScopedValue.where(InvalidDeclarationException.CONTEXT, method).run(() -> {
                 Definition definition = construct(method, context);
 

--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/EventHandler.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/EventHandler.java
@@ -42,7 +42,7 @@ public abstract sealed class EventHandler<T extends GenericInteractionCreateEven
         permits AutoCompleteHandler, ComponentHandler, ModalHandler, ContextCommandHandler, SlashCommandHandler {
 
     // will be replaced with ScopedValues when available
-    public static final ThreadLocal<Boolean> INVOCATION_PERMITTED = ThreadLocal.withInitial(() -> false);
+    public static final ScopedValue<Boolean> INVOCATION_PERMITTED = ScopedValue.newInstance();
 
     public static final Logger log = LoggerFactory.getLogger(EventHandler.class);
 
@@ -102,8 +102,7 @@ public abstract sealed class EventHandler<T extends GenericInteractionCreateEven
             );
             Object instance = runtime.interactionInstance(definition.classDescription().clazz());
 
-            INVOCATION_PERMITTED.set(true);
-            definition.invoke(instance, invocation);
+            ScopedValue.where(INVOCATION_PERMITTED, true).call(() -> definition.invoke(instance, invocation));
         } catch (Exception exception) {
             log.error("Interaction execution failed!", exception);
             // this unwraps the underlying error in case of an exception inside the command class

--- a/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/EventHandler.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/dispatching/handling/EventHandler.java
@@ -41,7 +41,6 @@ public abstract sealed class EventHandler<T extends GenericInteractionCreateEven
         implements BiConsumer<T, Runtime>
         permits AutoCompleteHandler, ComponentHandler, ModalHandler, ContextCommandHandler, SlashCommandHandler {
 
-    // will be replaced with ScopedValues when available
     public static final ScopedValue<Boolean> INVOCATION_PERMITTED = ScopedValue.newInstance();
 
     public static final Logger log = LoggerFactory.getLogger(EventHandler.class);

--- a/core/src/main/java/com/github/kaktushose/jda/commands/exceptions/InvalidDeclarationException.java
+++ b/core/src/main/java/com/github/kaktushose/jda/commands/exceptions/InvalidDeclarationException.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 /// Will be thrown if any errors are made in the declaration of interactions.
 public final class InvalidDeclarationException extends JDACException {
 
-    public static final ThreadLocal<MethodDescription> CONTEXT = new ThreadLocal<>();
+    public static final ScopedValue<MethodDescription> CONTEXT = ScopedValue.newInstance();
 
     /// @param key the bundle key of the error message
     public InvalidDeclarationException(String key) {

--- a/core/src/main/resources/jdac_internal_en.ftl
+++ b/core/src/main/resources/jdac_internal_en.ftl
@@ -61,6 +61,7 @@ member-context-guild = User context commands which use a Member object are only 
 jda-exception =
     { $cause }
     Interaction: "{ $type }" defined at "{ $class }#{ $method }".
+should-never-be-thrown = This exception should never be thrown!
 
 # Configuration Errors
 resource-not-found = Failed to find resource "{ $resource }".


### PR DESCRIPTION
Only ThreadLocal left is in I18n, but that isn't easily replaceable by ScopeValues, because this value isn't used nested.