### PR TITLE
Remove duplicate component check

### DIFF
--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/ConfigurableReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/ConfigurableReply.java
@@ -81,7 +81,7 @@ public sealed class ConfigurableReply extends MessageReply permits EditableConfi
         componentTree = componentTree.replace(ComponentReplacer.of(
                 io.github.kaktushose.jdac.dispatching.reply.Component.class,
                 _ -> true,
-                this::resolve
+                it -> resolve(it, true)
         ));
         return replyAction.reply(componentTree.getComponents());
     }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/ConfigurableReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/ConfigurableReply.java
@@ -81,7 +81,7 @@ public sealed class ConfigurableReply extends MessageReply permits EditableConfi
         componentTree = componentTree.replace(ComponentReplacer.of(
                 io.github.kaktushose.jdac.dispatching.reply.Component.class,
                 _ -> true,
-                it -> resolve(it, true)
+                this::resolve
         ));
         return replyAction.reply(componentTree.getComponents());
     }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/EditableConfigurableReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/EditableConfigurableReply.java
@@ -83,7 +83,7 @@ public final class EditableConfigurableReply extends ConfigurableReply {
         replacer[replacer.length -1] = ComponentReplacer.of(
                 io.github.kaktushose.jdac.dispatching.reply.Component.class,
                 _ -> true,
-                it -> resolve(it, false)
+                this::resolve
         );
 
         return replyAction.reply(replacer);

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/EditableConfigurableReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/EditableConfigurableReply.java
@@ -8,6 +8,8 @@ import net.dv8tion.jda.api.components.replacer.ComponentReplacer;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.interactions.components.ComponentInteraction;
 
+import java.util.Arrays;
+
 /// Subtype of [ConfigurableReply] that is used for [ComponentInteractions][net.dv8tion.jda.api.interactions.components.ComponentInteraction],
 /// where you can also edit the original reply instead of sending a new one.
 public final class EditableConfigurableReply extends ConfigurableReply {
@@ -76,6 +78,13 @@ public final class EditableConfigurableReply extends ConfigurableReply {
         }
 
         replyAction.keepComponents(true);
+
+        replacer = Arrays.copyOf(replacer, replacer.length + 1);
+        replacer[replacer.length -1] = ComponentReplacer.of(
+                io.github.kaktushose.jdac.dispatching.reply.Component.class,
+                _ -> true,
+                it -> resolve(it, false)
+        );
 
         return replyAction.reply(replacer);
     }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/MessageReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/MessageReply.java
@@ -191,14 +191,14 @@ public sealed class MessageReply permits ConfigurableReply, SendableReply {
     /// ```
     /// @see Component
     public SendableReply components(Component<?, ?, ?, ?>... components) {
-        List<ActionRowChildComponent> items = Arrays.stream(components).map(this::resolve).toList();
+        List<ActionRowChildComponent> items = Arrays.stream(components).map(it -> resolve(it, true)).toList();
         if (!items.isEmpty()) {
             replyAction.addComponents(ActionRow.of(items));
         }
         return new SendableReply(this);
     }
 
-    protected ActionRowChildComponent resolve(Component<?, ?, ?, ?> component) {
+    protected ActionRowChildComponent resolve(Component<?, ?, ?, ?> component, boolean checkDuplicate) {
         var className = component.origin().map(Class::getName)
                 .orElseGet(() -> getInvocationContext().definition().methodDescription().declaringClass().getName());
         String definitionId = InteractionDefinition.createDefinitionId(className, component.name());
@@ -210,9 +210,9 @@ public sealed class MessageReply permits ConfigurableReply, SendableReply {
                 .filter(Objects::nonNull)
                 .map(CustomId::fromMerged)
                 .anyMatch(customId -> customId.definitionId().equals(definitionId));
-        if (duplicate) {
+        if (duplicate && checkDuplicate) {
             throw new IllegalArgumentException(
-                    JDACException.errorMessage("duplicate-component", entry("method", "%s#%s".formatted(className, component)))
+                    JDACException.errorMessage("duplicate-component", entry("method", "%s#%s".formatted(className, component.name())))
             );
         }
 

--- a/core/src/main/resources/jdac_internal_en.ftl
+++ b/core/src/main/resources/jdac_internal_en.ftl
@@ -115,7 +115,6 @@ independent-runtime-id = Provided custom id is runtime-independent.
 
 # ConfigurableReply
 modal-as-component = Modals cannot be attached as components! "{ $method }" is a modal method! You have to reply with "ModalReplyableEvent#replyModal".
-duplicate-component = Cannot add component "{ $method } multiple times.
 
 # EditableConfigurableReply
 component-replacer-v1 = Cannot use ComponentReplacers on a message that isn't Components V2. Upgrade this message to Components V2 first or

--- a/core/src/test/java/reply/ComponentsV1Test.java
+++ b/core/src/test/java/reply/ComponentsV1Test.java
@@ -105,13 +105,6 @@ class ComponentsV1Test {
         assertNull(reply.lastMessage());
     }
 
-    @Test
-    void testDuplicate() {
-        MessageEventReply reply = scenario.slash("duplicate").invoke();
-
-        assertTrue(reply.embeds().get(0).getDescription().contains("The command execution has unexpectedly failed."));
-    }
-
     @Interaction
     public static class TestController {
 


### PR DESCRIPTION
Discord already prevents duplicate component ids, we don't have to check it ourselfs. Our check also clashes with the ComponentReplacer