### PR TITLE
Make JDA event accessible for type adapaters

### DIFF
--- a/core/src/main/java/io/github/kaktushose/jdac/annotations/IntrospectionAccess.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/annotations/IntrospectionAccess.java
@@ -11,10 +11,11 @@ import java.lang.annotation.*;
 /// inside the method annotated with this annotation.
 ///
 /// If this annotation is present on a Class like [RuntimeCloseEvent] it's up to the use case which meaning this has, please
-/// read the javadocs there.
+/// read the Javadocs there.
 ///
 /// Only properties having at least the stage of [#value()] can be used.
-/// - [Stage#INTERACTION] includes [Stage#CONFIGURATION], [Stage#INITIALIZED] and [Stage#RUNTIME]
+/// - [Stage#INTERACTION] includes [Stage#CONFIGURATION], [Stage#INITIALIZED], [Stage#RUNTIME] and [Stage#PREPARATION]
+/// - [Stage#PREPARATION] includes [Stage#CONFIGURATION], [Stage#INITIALIZED] and [Stage#RUNTIME]
 /// - [Stage#RUNTIME] includes [Stage#CONFIGURATION] and [Stage#INITIALIZED]
 /// - [Stage#INITIALIZED] includes [Stage#CONFIGURATION]
 ///

--- a/core/src/main/java/io/github/kaktushose/jdac/configuration/Property.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/configuration/Property.java
@@ -5,7 +5,7 @@ import io.github.kaktushose.jdac.JDACommands;
 import io.github.kaktushose.jdac.annotations.IntrospectionAccess;
 import io.github.kaktushose.jdac.definitions.description.ClassFinder;
 import io.github.kaktushose.jdac.definitions.description.Descriptor;
-import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition;
+import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition.ReplyConfig;
 import io.github.kaktushose.jdac.definitions.interactions.command.CommandDefinition;
 import io.github.kaktushose.jdac.dispatching.adapter.AdapterType;
 import io.github.kaktushose.jdac.dispatching.adapter.TypeAdapter;
@@ -154,10 +154,10 @@ public sealed interface Property<T> permits Property.Enumeration, Property.Singl
     Property<CommandDefinition.CommandConfig> GLOBAL_COMMAND_CONFIG =
             new Singleton<>("GLOBAL_COMMAND_CONFIG", Category.USER_SETTABLE, CommandDefinition.CommandConfig.class, Stage.CONFIGURATION);
 
-    /// @see JDACBuilder#globalReplyConfig(InteractionDefinition.ReplyConfig)
+    /// @see JDACBuilder#globalReplyConfig(ReplyConfig)
     @PropertyInformation(stage = Stage.CONFIGURATION, category = Category.USER_SETTABLE)
-    Property<InteractionDefinition.ReplyConfig> GLOBAL_REPLY_CONFIG =
-            new Singleton<>("GLOBAL_REPLY_CONFIG", Category.USER_SETTABLE, InteractionDefinition.ReplyConfig.class, Stage.CONFIGURATION);
+    Property<ReplyConfig> GLOBAL_REPLY_CONFIG =
+            new Singleton<>("GLOBAL_REPLY_CONFIG", Category.USER_SETTABLE, ReplyConfig.class, Stage.CONFIGURATION);
 
     /// @see JDACBuilder#packages(String...)
     @PropertyInformation(stage = Stage.CONFIGURATION, category = Category.USER_SETTABLE, fallbackBehaviour = ACCUMULATE)
@@ -269,13 +269,13 @@ public sealed interface Property<T> permits Property.Enumeration, Property.Singl
     Property<KeyValueStore> KEY_VALUE_STORE =
             new Singleton<>("KEY_VALUE_STORE", Category.PROVIDED, KeyValueStore.class, Stage.RUNTIME);
 
+    // ------ preparation ---------
+    /// The [GenericInteractionCreateEvent] of this interaction. Same as [Event#jdaEvent()].
+    @PropertyInformation(stage = Stage.PREPARATION, category = Category.PROVIDED)
+    Property<GenericInteractionCreateEvent> JDA_EVENT =
+            new Singleton<>("JDA_EVENT", Category.PROVIDED, GenericInteractionCreateEvent.class, Stage.PREPARATION);
 
     // ------ interaction ---------
-    /// The [GenericInteractionCreateEvent] of this interaction. Same as [Event#jdaEvent()].
-    @PropertyInformation(stage = Stage.INTERACTION, category = Category.PROVIDED)
-    Property<GenericInteractionCreateEvent> JDA_EVENT =
-            new Singleton<>("JDA_EVENT", Category.PROVIDED, GenericInteractionCreateEvent.class, Stage.INTERACTION);
-
     /// The [InvocationContext] of this interaction. Same as in [Middleware#accept(InvocationContext)].
     @PropertyInformation(stage = Stage.INTERACTION, category = Category.PROVIDED)
     Property<InvocationContext<?>> INVOCATION_CONTEXT =

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/adapter/TypeAdapter.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/adapter/TypeAdapter.java
@@ -1,8 +1,9 @@
 package io.github.kaktushose.jdac.dispatching.adapter;
 
+import io.github.kaktushose.jdac.annotations.IntrospectionAccess;
+import io.github.kaktushose.jdac.introspection.Stage;
 import io.github.kaktushose.proteus.mapping.Mapper.UniMapper;
 import io.github.kaktushose.proteus.mapping.MappingResult;
-import org.jetbrains.annotations.NotNull;
 
 /// Generic top level interface for type adapting.
 ///
@@ -12,5 +13,6 @@ import org.jetbrains.annotations.NotNull;
 public interface TypeAdapter<S, T> extends UniMapper<S, T> {
     
     /// {@inheritDoc}
-    MappingResult<T> from(@NotNull S source, MappingContext<S, T> context);
+    @IntrospectionAccess(Stage.PREPARATION)
+    MappingResult<T> from(S source, MappingContext<S, T> context);
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/validation/Validator.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/validation/Validator.java
@@ -6,6 +6,7 @@ import io.github.kaktushose.jdac.annotations.constraints.NotPerm;
 import io.github.kaktushose.jdac.annotations.constraints.Perm;
 import io.github.kaktushose.jdac.dispatching.context.InvocationContext;
 import io.github.kaktushose.jdac.embeds.error.ErrorMessageFactory;
+import io.github.kaktushose.jdac.introspection.Stage;
 import io.github.kaktushose.jdac.introspection.internal.IntrospectionAccess;
 import io.github.kaktushose.jdac.message.i18n.I18n;
 import io.github.kaktushose.jdac.message.resolver.MessageResolver;
@@ -56,6 +57,7 @@ public interface Validator<T, A extends Annotation> {
     /// @param argument   the argument to validate
     /// @param annotation the corresponding annotation
     /// @param context    the corresponding [InvocationContext]
+    @io.github.kaktushose.jdac.annotations.IntrospectionAccess(Stage.INTERACTION)
     void apply(T argument, A annotation, Context context);
 
     /// This context provides access to the [InvocationContext] of this interaction and

--- a/core/src/main/java/io/github/kaktushose/jdac/introspection/Stage.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/introspection/Stage.java
@@ -10,16 +10,18 @@ import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 
 /// The stage or "level" inside the framework at which a properties value is set.
 ///
-/// JDACommands has the following stages in this order:
+/// JDA-Commands has the following stages in this order:
 /// 1. [#CONFIGURATION] -> setting of builder properties, extension loading, construction of framework components
 /// 2. [#INITIALIZED] -> after starting the framework (basically after [JDACBuilder#start()] completed), e.g. all definitions are indexed etc.
 /// 3. [#RUNTIME] -> inside a runtime but outside of processing an [GenericInteractionCreateEvent], e.g. when [InteractionControllerInstantiator#instance(Class, Introspection)] is called
-/// 4. [#INTERACTION] -> when processing an [GenericInteractionCreateEvent], e.g. in [Middleware#accept(InvocationContext)] or inside a user defined interaction controller method
+/// 4. [#PREPARATION] -> during the preparation of an [GenericInteractionCreateEvent] for the [#INTERACTION] stage, e.g. where type adapters get called
+/// 5. [#INTERACTION] -> when processing an [GenericInteractionCreateEvent], e.g. in [Middleware#accept(InvocationContext)] or inside a user defined interaction controller method
 ///
 /// Generally, a stage includes all properties that were set in a former stage:
-/// - [Stage#INTERACTION] includes [Stage#CONFIGURATION], [Stage#INITIALIZED] and [Stage#RUNTIME]
-/// - [Stage#RUNTIME] includes [Stage#CONFIGURATION] and [Stage#INITIALIZED]
-/// - [Stage#INITIALIZED] includes [Stage#CONFIGURATION]
+/// - [#INTERACTION] includes [#CONFIGURATION], [#INITIALIZED], [#RUNTIME] and [#PREPARATION]
+/// - [#PREPARATION] includes [#CONFIGURATION], [#INITIALIZED] and [#RUNTIME]
+/// - [#RUNTIME] includes [#CONFIGURATION] and [#INITIALIZED]
+/// - [#INITIALIZED] includes [#CONFIGURATION]
 ///
 /// To know in which stage a [Property] is available take a look at [Property#stage()].
 ///
@@ -34,5 +36,6 @@ public enum Stage {
     CONFIGURATION,
     INITIALIZED,
     RUNTIME,
+    PREPARATION,
     INTERACTION
 }


### PR DESCRIPTION
introduces a new `Preparation` stage to make the GenericInteractionCreateEvent accessible for type adapters