### PR TITLE
Use `complete()` where applicable

### DIFF
--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/ModalReplyableEvent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/ModalReplyableEvent.java
@@ -101,6 +101,6 @@ public abstract sealed class ModalReplyableEvent<T extends GenericInteractionCre
         );
 
         log.debug("Replying to interaction \"{}\" with Modal: \"{}\". [Runtime={}]", definition.displayName(), modalDefinition.displayName(), runtimeId());
-        callback.replyModal(modalDefinition.toJDAEntity(new CustomId(runtimeId(), definitionId))).queue();
+        callback.replyModal(modalDefinition.toJDAEntity(new CustomId(runtimeId(), definitionId))).complete();
     }
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/interactions/AutoCompleteEvent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/interactions/AutoCompleteEvent.java
@@ -33,7 +33,7 @@ public final class AutoCompleteEvent extends Event<CommandAutoCompleteInteractio
      *                                  </ul>
      */
     public void replyChoices(Collection<Command.Choice> choices) {
-        jdaEvent().replyChoices(choices).queue();
+        jdaEvent().replyChoices(choices).complete();
     }
 
     /**

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/handling/EventHandler.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/handling/EventHandler.java
@@ -148,7 +148,7 @@ public abstract sealed class EventHandler<T extends GenericInteractionCreateEven
             if (invocation.event() instanceof GenericComponentInteractionCreateEvent componentEvent && !edit) {
                 Message message = componentEvent.getMessage();
                 if (Helpers.isValidWithoutComponents(message)) {
-                    message.editMessageComponents().queue();
+                    message.editMessageComponents().complete();
                 } else {
                     edit = true;
                 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/handling/command/SlashCommandHandler.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/handling/command/SlashCommandHandler.java
@@ -105,7 +105,7 @@ public final class SlashCommandHandler extends EventHandler<SlashCommandInteract
                                     .setEphemeral(replyConfig.ephemeral())
                                     .setSuppressedNotifications(replyConfig.silent())
                                     .setAllowedMentions(replyConfig.allowedMentions())
-                                    .queue();
+                                    .complete();
                             return Optional.empty();
                         }
                         case NO_PATH_FOUND, NO_LOSSLESS_CONVERSION -> throw new InternalException(


### PR DESCRIPTION
Replaces `queue()` with `complete()` where applicable. `queue()` remains for:
- JDAEventListener
- CommandUpdater

closes #316 