### PR TITLE
fix autocomplete cancellation in middlewares

### DIFF
--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/context/InvocationContext.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/context/InvocationContext.java
@@ -8,7 +8,9 @@ import io.github.kaktushose.jdac.embeds.error.ErrorMessageFactory.ErrorContext;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
 import io.github.kaktushose.jdac.message.resolver.MessageResolver;
 import net.dv8tion.jda.api.components.MessageTopLevelComponent;
+import net.dv8tion.jda.api.events.interaction.GenericAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.interactions.commands.Command.Choice;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.jspecify.annotations.Nullable;
 
@@ -40,21 +42,55 @@ public record InvocationContext<T extends GenericInteractionCreateEvent>(
 
     /// Stops further execution of this invocation at the next suitable moment.
     ///
+    /// If the underlying event is an [GenericAutoCompleteInteractionEvent], replies with empty [Choice]s and the
+    /// provided message isn't used.
+    ///
     /// @param errorMessage the error message that should be sent to the user as a reply
     /// @implNote This will interrupt the current event thread
     public void cancel(MessageCreateData errorMessage) {
+        if (event instanceof GenericAutoCompleteInteractionEvent) {
+            cancelAutoComplete();
+            return;
+        }
         replyAction().reply(errorMessage);
         Thread.currentThread().interrupt();
     }
 
     /// Stops further execution of this invocation at the next suitable moment.
     ///
+    /// If the underlying event is an [GenericAutoCompleteInteractionEvent], replies with empty [Choice]s and the
+    /// provided message isn't used.
+    ///
     /// @param component    the [MessageTopLevelComponent] that should be sent to the user as an error message
     /// @param placeholders the [Entry] placeholders to use for [message resolution][MessageResolver]
     /// @implNote This will interrupt the current event thread
     public void cancel(MessageTopLevelComponent component, Entry... placeholders) {
+        if (event instanceof GenericAutoCompleteInteractionEvent) {
+            cancelAutoComplete();
+            return;
+        }
         replyAction().reply(component, placeholders);
         Thread.currentThread().interrupt();
+    }
+
+    /// Stops further execution of this invocation at the next suitable moment if the underlying event is an
+    /// [GenericAutoCompleteInteractionEvent], else does nothing.
+    ///
+    /// @param choice the [Choice] to reply with. This can be useful to display an error message in the auto complete UI instead of failing silently
+    public void cancel(Choice choice) {
+        if (event instanceof GenericAutoCompleteInteractionEvent autoCompleteEvent) {
+            autoCompleteEvent.replyChoices(choice).complete();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /// Stops further execution of this invocation at the next suitable moment if the underlying event is an
+    /// [GenericAutoCompleteInteractionEvent], else does nothing.
+    public void cancelAutoComplete() {
+        if (event instanceof GenericAutoCompleteInteractionEvent autoCompleteEvent) {
+            autoCompleteEvent.replyChoices().complete();
+            Thread.currentThread().interrupt();
+        }
     }
 
     private ReplyAction replyAction() {

--- a/core/src/main/resources/jdac_internal_en.ftl
+++ b/core/src/main/resources/jdac_internal_en.ftl
@@ -132,8 +132,6 @@ cycling-tree =
 duplicate-component =
     Reply failed due to duplicate component ids. This likely happened because you tried to reply to a ComponentEvent with keepComponents enabled.
     Try disabling keepComponents or assign different unique ids to your components.
-cancel-autocomplete = Cannot cancel auto complete events with message content. Use InvocationContext#cancelAutoComplete() instead.
-cancel-non-autocomplete = Cannot cancel non auto complete event with this method. Use InvocationContext#cancel(MessageCreateData) or InvocationContext#cancel(MessageTopLevelComponent) instead.
 
 # CustomId
 invalid-runtime-id = Invalid runtime id! Must either be a UUID or "independent".

--- a/core/src/main/resources/jdac_internal_en.ftl
+++ b/core/src/main/resources/jdac_internal_en.ftl
@@ -132,6 +132,8 @@ cycling-tree =
 duplicate-component =
     Reply failed due to duplicate component ids. This likely happened because you tried to reply to a ComponentEvent with keepComponents enabled.
     Try disabling keepComponents or assign different unique ids to your components.
+cancel-autocomplete = Cannot cancel auto complete events with message content. Use InvocationContext#cancelAutoComplete() instead.
+cancel-non-autocomplete = Cannot cancel non auto complete event with this method. Use InvocationContext#cancel(MessageCreateData) or InvocationContext#cancel(MessageTopLevelComponent) instead.
 
 # CustomId
 invalid-runtime-id = Invalid runtime id! Must either be a UUID or "independent".


### PR DESCRIPTION
## Type
- [ ] Feature
- [x] Fix
- [ ] Refactor

## Description
Fixes the cancellation of auto complete events in middlewares. Adds two new methods to explicitly cancel auto complete events and adds fallback behaviour to the message bound methods.

### Example
<!-- only fill out for feature prs -->
```java
@Override
public void accept(InvocationContext<?> context) {
    context.cancelAutoComplete();
    // or 
    context.cancel(new Command.Choice("You are not allowed to use auto complete", 0));
}
```

## Checklist

- [x] Applied IntelliJ Formatter (`Ctrl` + `Shift` + `L`)
- [x] Applied `gradle format`
- [ ] If applicable, added unit tests
- [x] Updated documentation
