### PR TITLE
Add missing `required` field to select menus

### DIFF
--- a/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/EntityMenu.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/EntityMenu.java
@@ -89,4 +89,18 @@ public @interface EntityMenu {
 
     /// The uniqueId of this component. Must be greater than 0. Default value is `-1` which will result in Discord auto assigning an id.
     int uniqueId() default -1;
+
+    /// Configure whether the user must populate this select menu if inside a Modal.
+    ///
+    /// This defaults to `true` in Modals when unset.
+    ///
+    /// This attribute is completely separate from the value range,
+    /// for example, you can have an optional select menu with the range set to `[2 ; 5]`,
+    /// meaning you accept either 0 options, or, at least 2 but at most 5.
+    ///
+    /// This only has an effect in Modals!
+    ///
+    /// @return Whether this menu is required
+    boolean required() default true;
+
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/StringMenu.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/StringMenu.java
@@ -61,4 +61,17 @@ public @interface StringMenu {
 
     /// The uniqueId of this component. Must be greater than 0. Default value is `-1` which will result in Discord auto assigning an id.
     int uniqueId() default -1;
+
+    /// Configure whether the user must populate this select menu if inside a Modal.
+    ///
+    /// This defaults to `true` in Modals when unset.
+    ///
+    /// This attribute is completely separate from the value range,
+    /// for example, you can have an optional select menu with the range set to `[2 ; 5]`,
+    /// meaning you accept either 0 options, or, at least 2 but at most 5.
+    ///
+    /// This only has an effect in Modals!
+    ///
+    /// @return Whether this menu is required
+    boolean required() default true;
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/EntitySelectMenuDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/EntitySelectMenuDefinition.java
@@ -40,7 +40,8 @@ public record EntitySelectMenuDefinition(
         String placeholder,
         int minValue,
         int maxValue,
-        @Nullable Integer uniqueId
+        @Nullable Integer uniqueId,
+        boolean required
 ) implements SelectMenuDefinition<EntitySelectMenu> {
 
     /// Builds a new [EntitySelectMenuDefinition] from the given [MethodBuildContext].
@@ -82,7 +83,8 @@ public record EntitySelectMenuDefinition(
                 selectMenu.placeholder(),
                 selectMenu.minValue(),
                 selectMenu.maxValue(),
-                selectMenu.uniqueId() < 0 ? null : selectMenu.uniqueId()
+                selectMenu.uniqueId() < 0 ? null : selectMenu.uniqueId(),
+                selectMenu.required()
         );
     }
 
@@ -94,7 +96,8 @@ public record EntitySelectMenuDefinition(
                                            @Nullable String placeholder,
                                            @Nullable Integer minValue,
                                            @Nullable Integer maxValue,
-                                           @Nullable Integer uniqueId) {
+                                           @Nullable Integer uniqueId,
+                                           @Nullable Boolean required) {
         return new EntitySelectMenuDefinition(
                 classDescription,
                 methodDescription,
@@ -105,7 +108,8 @@ public record EntitySelectMenuDefinition(
                 override(this.placeholder, placeholder),
                 override(this.minValue, minValue),
                 override(this.maxValue, maxValue),
-                override(this.uniqueId, uniqueId)
+                override(this.uniqueId, uniqueId),
+                override(this.required, required)
         );
     }
 
@@ -128,7 +132,8 @@ public record EntitySelectMenuDefinition(
             var menu = EntitySelectMenu.create(customId.merged(), selectTargets)
                     .setDefaultValues(defaultValues)
                     .setPlaceholder(placeholder)
-                    .setRequiredRange(minValue, maxValue);
+                    .setRequiredRange(minValue, maxValue)
+                    .setRequired(required);
 
             // ChannelType.UNKNOWN is the default value inside the annotation. if this statement is true, we can assume that
             // no channel type was selected

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/SelectMenuDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/SelectMenuDefinition.java
@@ -19,4 +19,7 @@ public sealed interface SelectMenuDefinition<T extends SelectMenu> extends Compo
     /// the maximum amount of choices
     int maxValue();
 
+    /// whether this menu is required. This only has an effect in Modals.
+    boolean required();
+
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/StringSelectMenuDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/StringSelectMenuDefinition.java
@@ -40,7 +40,8 @@ public record StringSelectMenuDefinition(
         String placeholder,
         int minValue,
         int maxValue,
-        @Nullable Integer uniqueId
+        @Nullable Integer uniqueId,
+        boolean required
 ) implements SelectMenuDefinition<StringSelectMenu> {
 
     /// Builds a new [StringSelectMenuDefinition] from the given [MethodBuildContext].
@@ -79,7 +80,8 @@ public record StringSelectMenuDefinition(
                 selectMenu.value(),
                 selectMenu.minValue(),
                 selectMenu.maxValue(),
-                selectMenu.uniqueId() < 0 ? null : selectMenu.uniqueId()
+                selectMenu.uniqueId() < 0 ? null : selectMenu.uniqueId(),
+                selectMenu.required()
         );
     }
 
@@ -90,7 +92,8 @@ public record StringSelectMenuDefinition(
                                            @Nullable String placeholder,
                                            @Nullable Integer minValue,
                                            @Nullable Integer maxValue,
-                                           @Nullable Integer uniqueId) {
+                                           @Nullable Integer uniqueId,
+                                           @Nullable Boolean required) {
         return new StringSelectMenuDefinition(
                 this.classDescription,
                 this.methodDescription,
@@ -99,7 +102,8 @@ public record StringSelectMenuDefinition(
                 override(this.placeholder, placeholder),
                 override(this.minValue, minValue),
                 override(this.maxValue, maxValue),
-                override(this.uniqueId, uniqueId)
+                override(this.uniqueId, uniqueId),
+                override(this.required, required)
         );
     }
 
@@ -133,6 +137,7 @@ public record StringSelectMenuDefinition(
                     .setPlaceholder(placeholder)
                     .setRequiredRange(minValue, maxValue)
                     .addOptions(selectOptions.stream().map(MenuOptionDefinition::toJDAEntity).toList())
+                    .setRequired(required)
                     .build();
             if (uniqueId != null) {
                 menu = menu.withUniqueId(uniqueId);

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/dynamic/menu/EntitySelectMenuComponent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/dynamic/menu/EntitySelectMenuComponent.java
@@ -69,7 +69,7 @@ public final class EntitySelectMenuComponent extends SelectMenuComponent<EntityS
 
     @Override
     protected EntitySelectMenuDefinition build(EntitySelectMenuDefinition definition) {
-        return definition.with(entityTypes, defaultValues, channelTypes, placeholder, minValues, maxValues, uniqueId);
+        return definition.with(entityTypes, defaultValues, channelTypes, placeholder, minValues, maxValues, uniqueId, required);
     }
 
     @Override

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/dynamic/menu/SelectMenuComponent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/dynamic/menu/SelectMenuComponent.java
@@ -26,6 +26,7 @@ public sealed abstract class SelectMenuComponent<S extends SelectMenuComponent<S
     // wrapper types for nullability (null -> not set)
     protected @Nullable Integer minValues;
     protected @Nullable Integer maxValues;
+    protected @Nullable Boolean required;
 
     public SelectMenuComponent(String method, @Nullable Class<?> origin, Entry[] placeholder) {
         super(method, origin, placeholder);
@@ -53,6 +54,12 @@ public sealed abstract class SelectMenuComponent<S extends SelectMenuComponent<S
     public S requiresRange(int min, int max) {
         minValues(min);
         maxValues(max);
+        return self();
+    }
+
+    /// @see SelectMenu.Builder#setRequired(Boolean)
+    public S required(@Nullable Boolean required) {
+        this.required = required;
         return self();
     }
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/dynamic/menu/StringSelectComponent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/dynamic/menu/StringSelectComponent.java
@@ -86,7 +86,7 @@ public final class StringSelectComponent extends SelectMenuComponent<StringSelec
 
     @Override
     protected StringSelectMenuDefinition build(StringSelectMenuDefinition definition) {
-        return definition.with(selectOptions, defaultValues, placeholder, minValues, maxValues, uniqueId);
+        return definition.with(selectOptions, defaultValues, placeholder, minValues, maxValues, uniqueId, required);
     }
 
     @Override

--- a/core/src/test/java/definitions/interactions/component/EntitySelectMenuDefinitionTest.java
+++ b/core/src/test/java/definitions/interactions/component/EntitySelectMenuDefinitionTest.java
@@ -68,7 +68,7 @@ class EntitySelectMenuDefinitionTest {
         var newDefaults = Set.of(DefaultValue.user(42L));
         var newChannelTypes = Set.of(ChannelType.NEWS);
 
-        var overridden = base.with(newTargets, newDefaults, newChannelTypes, "new placeholder", 2, 3, 1);
+        var overridden = base.with(newTargets, newDefaults, newChannelTypes, "new placeholder", 2, 3, 1, false);
 
         assertTrue(overridden.selectTargets().contains(SelectTarget.USER));
         assertTrue(overridden.defaultValues().stream().anyMatch(d -> d.getIdLong() == 42L));

--- a/core/src/test/java/definitions/interactions/component/StringSelectMenuDefinitionTest.java
+++ b/core/src/test/java/definitions/interactions/component/StringSelectMenuDefinitionTest.java
@@ -80,7 +80,7 @@ class StringSelectMenuDefinitionTest {
         SelectOption existingOption = SelectOption.of("Label 1", "v1");
         SelectOption newOption = SelectOption.of("Label 2", "v2");
 
-        var overridden = base.with(List.of(existingOption, newOption), List.of("v2"), "New placeholder", 2, 3, 1);
+        var overridden = base.with(List.of(existingOption, newOption), List.of("v2"), "New placeholder", 2, 3, 1, false);
 
         assertEquals("New placeholder", overridden.placeholder());
         assertEquals(2, overridden.minValue());


### PR DESCRIPTION
## Type
- [ ] Feature
- [x] Fix
- [ ] Refactor

## Description
Adds the missing `isRequired` field to entity and string select menus. This field was introduced with components v2 and was left out in the original feature pr. 

### Example
<!-- only fill out for feature prs -->
```java
Label.of("Select an option", Component.stringSelect("onMenu").required(false))
```

## Checklist

- [x] Applied IntelliJ Formatter (`Ctrl` + `Shift` + `L`)
- [x] Applied `gradle format`
- [ ] If applicable, added unit tests
- [x] Updated documentation
