### PR TITLE
Publish InteractionFinishedEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license-shield](https://img.shields.io/badge/License-Apache%202.0-lightgrey.svg)]()
 
 # JDA-Commands
- 
+
 A lightweight, easy-to-use command framework for building Discord bots
 with [JDA](https://github.com/DV8FromTheWorld/JDA) with full support for interactions. JDA-Commands goal is to remove
 any boilerplate code, so you can focus solely on the business logic of your bot - writing bots has never been easier!

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ spotless {
 
     java {
         target("**/*.java")
-        targetExclude(".github/workflows/**")
+        targetExclude(".github/workflows/**", "build/**", "**/.direnv/**")
 
         importOrder("io.github.kaktushose|dev.goldmensch|net.dv8tion|", "java|javax", "\\#")
         forbidModuleImports()

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/features/internal/Invokable.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/features/internal/Invokable.java
@@ -29,8 +29,7 @@ public sealed interface Invokable extends Definition permits InteractionDefiniti
     /// @throws IllegalAccessException    if the method object is enforcing Java language access control and the
     ///                                   underlying method is inaccessible
     /// @throws InvocationTargetException if an exception was thrown by the invoked method or constructor
-    @Nullable
-    @ApiStatus.Internal
+    @Nullable @ApiStatus.Internal
     default Object invoke(Object instance, InvocationContext<?> invocation) throws IllegalAccessException, InvocationTargetException {
         if (!EventHandler.INVOCATION_PERMITTED.orElse(false)) {
             throw new InternalException("invocation-not-permitted");

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/Event.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/Event.java
@@ -147,8 +147,7 @@ public abstract sealed class Event<T extends GenericInteractionCreateEvent> impl
         return jdaEvent().getToken();
     }
 
-    @Nullable
-    @Override
+    @Nullable @Override
     public Guild getGuild() {
         return jdaEvent().getGuild();
     }
@@ -158,8 +157,7 @@ public abstract sealed class Event<T extends GenericInteractionCreateEvent> impl
         return jdaEvent().getUser();
     }
 
-    @Nullable
-    @Override
+    @Nullable @Override
     public Member getMember() {
         return jdaEvent().getMember();
     }
@@ -169,8 +167,7 @@ public abstract sealed class Event<T extends GenericInteractionCreateEvent> impl
         return jdaEvent().isAcknowledged();
     }
 
-    @Nullable
-    @Override
+    @Nullable @Override
     public Channel getChannel() {
         return jdaEvent().getChannel();
     }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/handling/EventHandler.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/handling/EventHandler.java
@@ -15,6 +15,7 @@ import io.github.kaktushose.jdac.embeds.error.ErrorMessageFactory;
 import io.github.kaktushose.jdac.internal.Helpers;
 import io.github.kaktushose.jdac.property.JDACProperty;
 import io.github.kaktushose.jdac.property.JDACScope;
+import io.github.kaktushose.jdac.property.events.InteractionFinishedEvent;
 import io.github.kaktushose.jdac.property.events.InteractionStartEvent;
 import io.github.kaktushose.jdac.property.internal.JDACInternalProperties;
 import io.github.kaktushose.jdac.property.internal.JDACIntrospectionImpl;
@@ -129,14 +130,17 @@ public abstract sealed class EventHandler<T extends GenericInteractionCreateEven
             Object instance = runtime.interactionInstance(definition.classDescription().clazz());
 
             ScopedValue.where(INVOCATION_PERMITTED, true).call(() -> definition.invoke(instance, invocation));
-        } catch (Exception exception) {
+            introspection.publish(new InteractionFinishedEvent(invocation, null));
+        } catch (Throwable throwable) {
             // this unwraps the underlying error in case of an exception inside the command class
-            Throwable throwable = exception instanceof InvocationTargetException ? exception.getCause() : exception;
-            log.error("Interaction execution failed!", throwable);
+            Throwable original = throwable instanceof InvocationTargetException ? throwable.getCause() : throwable;
+            log.error("Interaction execution failed!", original);
+
+            introspection.publish(new InteractionFinishedEvent(invocation, original));
 
             // 10062 is the error code for "Unknown interaction". In that case we cannot send any reply, not even the
             // error message.
-            if (throwable instanceof ErrorResponseException errorResponse && errorResponse.getErrorCode() == 10062) {
+            if (original instanceof ErrorResponseException errorResponse && errorResponse.getErrorCode() == 10062) {
                 return;
             }
 
@@ -161,7 +165,7 @@ public abstract sealed class EventHandler<T extends GenericInteractionCreateEven
                     replyConfig.silent(),
                     replyConfig.allowedMentions()
             )
-            ).reply(errorMessageFactory.getInteractionExecutionFailedMessage(invocation, throwable));
+            ).reply(errorMessageFactory.getInteractionExecutionFailedMessage(invocation, original));
         }
     }
 

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/handling/command/SlashCommandHandler.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/handling/command/SlashCommandHandler.java
@@ -48,8 +48,7 @@ public final class SlashCommandHandler extends EventHandler<SlashCommandInteract
     }
 
     @Override
-    @Nullable
-    protected PreparationResult prepare(SlashCommandInteractionEvent event, Runtime runtime) {
+    @Nullable protected PreparationResult prepare(SlashCommandInteractionEvent event, Runtime runtime) {
         SlashCommandDefinition command = interactionRegistry.find(SlashCommandDefinition.class, true, it ->
                 it.name().equals(event.getFullCommandName())
         );

--- a/core/src/main/java/io/github/kaktushose/jdac/property/events/InteractionFinishedEvent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/property/events/InteractionFinishedEvent.java
@@ -6,15 +6,17 @@ import io.github.kaktushose.jdac.dispatching.context.InvocationContext;
 import io.github.kaktushose.jdac.property.JDACScope;
 import org.jspecify.annotations.Nullable;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.SequencedCollection;
 
 /// Published after an interaction controller method is called.
 ///
 /// @param invocationContext the [InvocationContext] that was used to invoke the interaction controller method
-/// @param exception         the [Exception] thrown by [Invoker#invoke(Object, SequencedCollection)] or `null` if no exception was thrown
+/// @param exception         the [Throwable] thrown by [Invoker#invoke(Object, SequencedCollection)] or `null` if no exception was thrown.
+///                          If an [InvocationTargetException] is thrown, the [cause][InvocationTargetException#getCause()] is unwrapped and passed instead.
 @IntrospectionAccess(JDACScope.INTERACTION)
 public record InteractionFinishedEvent(
         InvocationContext<?> invocationContext,
-        @Nullable Exception exception
+        @Nullable Throwable exception
 ) implements JDACEvent {
 }

--- a/core/src/test/java/dispatching/context/KeyValueStoreTest.java
+++ b/core/src/test/java/dispatching/context/KeyValueStoreTest.java
@@ -53,7 +53,7 @@ class KeyValueStoreTest {
     void putAndGetWithKey() {
         Key<String> key = new Key<>("key", String.class);
         store.put(key, "value");
-        
+
         Optional<String> result = store.get(key);
         assertTrue(result.isPresent());
         assertEquals("value", result.get());
@@ -70,9 +70,9 @@ class KeyValueStoreTest {
     void containsWithKey() {
         Key<String> key = new Key<>("key", String.class);
         Key<Integer> wrongTypeKey = new Key<>("key", Integer.class);
-        
+
         store.put(key, "value");
-        
+
         assertTrue(store.contains(key));
         assertFalse(store.contains(wrongTypeKey));
     }
@@ -96,9 +96,9 @@ class KeyValueStoreTest {
     void clear_ShouldRemoveAllValues() {
         store.put("key1", "value1");
         store.put("key2", 2);
-        
+
         store.clear();
-        
+
         assertFalse(store.contains("key1"));
         assertFalse(store.contains("key2"));
     }
@@ -115,7 +115,7 @@ class KeyValueStoreTest {
     void getWithKey_Inheritance() {
         Key<Number> key = new Key<>("key", Number.class);
         store.put(key, 10); // Stores Integer
-        
+
         Optional<Number> result = store.get(key);
         assertTrue(result.isPresent());
         assertEquals(10, result.get());

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
             virtualenv
             python312Packages.pip
             python312
+            nodejs_24
         ];
        in {
          devShells.default = pkgs.mkShell {


### PR DESCRIPTION
## Type
- [ ] Feature
- [x] Fix
- [ ] Refactor

## Description
Publishes the InteractionFinishEvent after an interaction controller method call returned, perhaps exposing the thrown exception to the user.

This PR comes with a small breaking change (using Throwable instead of exception inside InteractionFinishEvent), which is needed because unwrapping InvocationTargetException leaves us with a Throwable. Since this event wasn't even functional yet, I think it should be safe to introduce this change *without* a mayor bump.

## Checklist

- [x] Applied IntelliJ Formatter (`Ctrl` + `Shift` + `L`)
- [x] Applied `gradle format`
- [ ] If applicable, added unit tests
- [ ] Updated documentation
