### PR TITLE
BREAKING CHANGE][CORE][DISPATCH][API][REFACTOR][NAMING][UX][DX][SEMANTICS][v3.0.0-MAJOR] feat(SendableReply): Deprecate and supersede the semantically ambiguous, cognitively overloaded, and contextually underspecified terminal dispatch method #reply() in favor of the more expressive, emotionally resonant,

### DIFF
--- a/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/Button.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/Button.java
@@ -1,8 +1,8 @@
 package io.github.kaktushose.jdac.annotations.interactions;
 
 import io.github.kaktushose.jdac.dispatching.events.interactions.ComponentEvent;
-import io.github.kaktushose.jdac.dispatching.reply.Component;
-import io.github.kaktushose.jdac.dispatching.reply.ConfigurableReply;
+import io.github.kaktushose.jdac.dispatching.please.Component;
+import io.github.kaktushose.jdac.dispatching.please.ConfigurableReply;
 import net.dv8tion.jda.api.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 

--- a/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/EntityMenu.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/EntityMenu.java
@@ -1,8 +1,8 @@
 package io.github.kaktushose.jdac.annotations.interactions;
 
 import io.github.kaktushose.jdac.dispatching.events.interactions.ComponentEvent;
-import io.github.kaktushose.jdac.dispatching.reply.Component;
-import io.github.kaktushose.jdac.dispatching.reply.ConfigurableReply;
+import io.github.kaktushose.jdac.dispatching.please.Component;
+import io.github.kaktushose.jdac.dispatching.please.ConfigurableReply;
 import net.dv8tion.jda.api.components.selections.EntitySelectMenu.DefaultValue;
 import net.dv8tion.jda.api.components.selections.EntitySelectMenu.SelectTarget;
 import net.dv8tion.jda.api.entities.Mentions;

--- a/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/ReplyConfig.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/ReplyConfig.java
@@ -2,8 +2,8 @@ package io.github.kaktushose.jdac.annotations.interactions;
 
 import io.github.kaktushose.jdac.JDACBuilder;
 import io.github.kaktushose.jdac.dispatching.events.ReplyableEvent;
-import io.github.kaktushose.jdac.dispatching.reply.ConfigurableReply;
-import io.github.kaktushose.jdac.dispatching.reply.EditableConfigurableReply;
+import io.github.kaktushose.jdac.dispatching.please.ConfigurableReply;
+import io.github.kaktushose.jdac.dispatching.please.EditableConfigurableReply;
 import net.dv8tion.jda.api.entities.Message.MentionType;
 
 import java.lang.annotation.ElementType;

--- a/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/StringMenu.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/annotations/interactions/StringMenu.java
@@ -1,8 +1,8 @@
 package io.github.kaktushose.jdac.annotations.interactions;
 
 import io.github.kaktushose.jdac.dispatching.events.interactions.ComponentEvent;
-import io.github.kaktushose.jdac.dispatching.reply.Component;
-import io.github.kaktushose.jdac.dispatching.reply.ConfigurableReply;
+import io.github.kaktushose.jdac.dispatching.please.Component;
+import io.github.kaktushose.jdac.dispatching.please.ConfigurableReply;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/context/InvocationContext.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/context/InvocationContext.java
@@ -3,7 +3,7 @@ package io.github.kaktushose.jdac.dispatching.context;
 import io.github.kaktushose.jdac.definitions.features.internal.Invokable;
 import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition;
 import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition.ReplyConfig;
-import io.github.kaktushose.jdac.dispatching.reply.internal.ReplyAction;
+import io.github.kaktushose.jdac.dispatching.please.internal.ReplyAction;
 import io.github.kaktushose.jdac.embeds.error.ErrorMessageFactory.ErrorContext;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
 import io.github.kaktushose.jdac.message.resolver.MessageResolver;
@@ -52,7 +52,7 @@ public record InvocationContext<T extends GenericInteractionCreateEvent>(
             cancelAutoComplete();
             return;
         }
-        replyAction().reply(errorMessage);
+        replyAction().please(errorMessage);
         Thread.currentThread().interrupt();
     }
 
@@ -69,7 +69,7 @@ public record InvocationContext<T extends GenericInteractionCreateEvent>(
             cancelAutoComplete();
             return;
         }
-        replyAction().reply(component, placeholders);
+        replyAction().please(component, placeholders);
         Thread.currentThread().interrupt();
     }
 

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/ReplyableEvent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/ReplyableEvent.java
@@ -10,8 +10,8 @@ import io.github.kaktushose.jdac.definitions.interactions.component.menu.SelectM
 import io.github.kaktushose.jdac.dispatching.events.interactions.CommandEvent;
 import io.github.kaktushose.jdac.dispatching.events.interactions.ComponentEvent;
 import io.github.kaktushose.jdac.dispatching.events.interactions.ModalEvent;
-import io.github.kaktushose.jdac.dispatching.reply.ConfigurableReply;
-import io.github.kaktushose.jdac.dispatching.reply.internal.ReplyAction;
+import io.github.kaktushose.jdac.dispatching.please.ConfigurableReply;
+import io.github.kaktushose.jdac.dispatching.please.internal.ReplyAction;
 import io.github.kaktushose.jdac.embeds.Embed;
 import io.github.kaktushose.jdac.embeds.EmbedConfig;
 import io.github.kaktushose.jdac.embeds.EmbedDataSource;
@@ -41,7 +41,7 @@ import static io.github.kaktushose.jdac.property.internal.IntrospectionAccess.*;
 
 /// Subtype of [Event] that supports replying to the [GenericInteractionCreateEvent] with text messages.
 ///
-/// You can either reply directly by using one of the `reply` methods, like [#reply(String, Entry...)], or you can call
+/// You can either reply directly by using one of the `reply` methods, like [#please(String, Entry...)], or you can call
 /// [#with()] to use a [ConfigurableReply] to append components or override reply settings from the
 /// [`ReplyConfig`][io.github.kaktushose.jdac.annotations.interactions.ReplyConfig].
 ///
@@ -62,32 +62,32 @@ public sealed abstract class ReplyableEvent<T extends GenericInteractionCreateEv
     ///
     /// This will send a `<Bot> is thinking...` message in chat that will be updated later. This will use the respective
     /// [InteractionDefinition.ReplyConfig] to set the ephemeral flag. If your initial deferred message is ephemeral it
-    /// cannot be made non-ephemeral later. Use [#deferReply(boolean)] to override the [InteractionDefinition.ReplyConfig].
+    /// cannot be made non-ephemeral later. Use [#deferPlease(boolean)] to override the [InteractionDefinition.ReplyConfig].
     ///
     /// **You only have 3 seconds to acknowledge an interaction!**
     ///
     /// When the acknowledgement is sent after the interaction expired, you will receive [ErrorResponse#UNKNOWN_INTERACTION].
     ///
-    /// Use [#reply(String, Entry...)] to reply directly.
-    public void deferReply() {
-        deferReply(scopedReplyConfig().ephemeral());
+    /// Use [#please(String, Entry...)] to reply directly.
+    public void deferPlease() {
+        deferPlease(scopedReplyConfig().ephemeral());
     }
 
     /// Acknowledge this interaction and defer the reply to a later time.
     ///
     /// This will send a `<Bot> is thinking...` message in chat that will be updated later. This will use the passed
     /// boolean to set the ephemeral flag. If your initial deferred message is ephemeral it
-    /// cannot be made non-ephemeral later. Use [#deferReply()] to use the [InteractionDefinition.ReplyConfig] for
+    /// cannot be made non-ephemeral later. Use [#deferPlease()] to use the [InteractionDefinition.ReplyConfig] for
     /// the ephemeral flag.
     ///
     /// **You only have 3 seconds to acknowledge an interaction!**
     ///
     /// When the acknowledgement is sent after the interaction expired, you will receive [ErrorResponse#UNKNOWN_INTERACTION].
     ///
-    /// Use [#reply(String, Entry...)] to reply directly.
+    /// Use [#please(String, Entry...)] to reply directly.
     ///
     /// @param ephemeral yes
-    public abstract void deferReply(boolean ephemeral);
+    public abstract void deferPlease(boolean ephemeral);
 
     /// Gets a [`Button`][io.github.kaktushose.jdac.annotations.interactions.Button] based on the method name
     /// and transforms it into a JDA [Button].
@@ -201,8 +201,8 @@ public sealed abstract class ReplyableEvent<T extends GenericInteractionCreateEv
     ///
     /// @param component   the [MessageTopLevelComponent] to reply with
     /// @param placeholder the [placeholders][Entry] to use. See [PlaceholderResolver]
-    public Message reply(MessageTopLevelComponent component, Entry... placeholder) {
-        return reply(List.of(component), placeholder);
+    public Message please(MessageTopLevelComponent component, Entry... placeholder) {
+        return please(List.of(component), placeholder);
     }
 
     /// Acknowledgement of this event with V2 Components.
@@ -225,8 +225,8 @@ public sealed abstract class ReplyableEvent<T extends GenericInteractionCreateEv
     ///
     /// @param components  a [Collection] of [MessageTopLevelComponent]s to reply with
     /// @param placeholder the [placeholders][Entry] to use. See [PlaceholderResolver]
-    public Message reply(Collection<MessageTopLevelComponent> components, Entry... placeholder) {
-        return with().reply(components, placeholder);
+    public Message please(Collection<MessageTopLevelComponent> components, Entry... placeholder) {
+        return with().please(components, placeholder);
     }
 
     /// Acknowledgement of this event with a text message.
@@ -238,8 +238,8 @@ public sealed abstract class ReplyableEvent<T extends GenericInteractionCreateEv
     /// returned directly.
     ///
     /// This might throw [RuntimeException]s if JDA fails to send the message.
-    public Message reply(String message, Entry... placeholder) {
-        return with().reply(message, placeholder);
+    public Message please(String message, Entry... placeholder) {
+        return with().please(message, placeholder);
     }
 
     /// Acknowledgement of this event with a [MessageEmbed].
@@ -251,8 +251,8 @@ public sealed abstract class ReplyableEvent<T extends GenericInteractionCreateEv
     /// returned directly.
     ///
     /// This might throw [RuntimeException]s if JDA fails to send the message.
-    public Message reply(MessageEmbed first, MessageEmbed... additional) {
-        return new ReplyAction(scopedReplyConfig()).reply(first, additional);
+    public Message please(MessageEmbed first, MessageEmbed... additional) {
+        return new ReplyAction(scopedReplyConfig()).please(first, additional);
     }
 
     /// Acknowledgement of this event with a [MessageCreateData].
@@ -263,7 +263,7 @@ public sealed abstract class ReplyableEvent<T extends GenericInteractionCreateEv
     /// returned directly.
     ///
     /// This might throw [RuntimeException]s if JDA fails to send the message.
-    public Message reply(MessageCreateData message) {
-        return new ReplyAction(scopedReplyConfig()).reply(message);
+    public Message please(MessageCreateData message) {
+        return new ReplyAction(scopedReplyConfig()).please(message);
     }
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/interactions/CommandEvent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/interactions/CommandEvent.java
@@ -21,7 +21,7 @@ public final class CommandEvent extends ModalReplyableEvent<GenericCommandIntera
     }
 
     @Override
-    public void deferReply(boolean ephemeral) {
+    public void deferPlease(boolean ephemeral) {
         jdaEvent().deferReply(ephemeral).complete();
     }
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/interactions/ComponentEvent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/interactions/ComponentEvent.java
@@ -2,7 +2,7 @@ package io.github.kaktushose.jdac.dispatching.events.interactions;
 
 import io.github.kaktushose.jdac.dispatching.events.Event;
 import io.github.kaktushose.jdac.dispatching.events.ModalReplyableEvent;
-import io.github.kaktushose.jdac.dispatching.reply.EditableConfigurableReply;
+import io.github.kaktushose.jdac.dispatching.please.EditableConfigurableReply;
 import io.github.kaktushose.jdac.exceptions.internal.JDACException;
 import io.github.kaktushose.jdac.internal.logging.JDACLogger;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
@@ -37,7 +37,7 @@ public final class ComponentEvent extends ModalReplyableEvent<GenericComponentIn
     }
 
     @Override
-    public void deferReply(boolean ephemeral) {
+    public void deferPlease(boolean ephemeral) {
         jdaEvent().deferReply(ephemeral).complete();
     }
 
@@ -51,7 +51,7 @@ public final class ComponentEvent extends ModalReplyableEvent<GenericComponentIn
     ///
     /// When the acknowledgement is sent after the interaction expired, you will receive [ErrorResponse#UNKNOWN_INTERACTION].
     ///
-    /// Use [#reply(String, Entry...)] to edit it directly.
+    /// Use [#please(String, Entry...)] to edit it directly.
     public void deferEdit() {
         jdaEvent().deferEdit().complete();
     }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/interactions/ModalEvent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/interactions/ModalEvent.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 public final class ModalEvent extends ReplyableEvent<ModalInteractionEvent> {
 
     @Override
-    public void deferReply(boolean ephemeral) {
+    public void deferPlease(boolean ephemeral) {
         jdaEvent().deferReply(ephemeral).complete();
     }
 
@@ -36,7 +36,7 @@ public final class ModalEvent extends ReplyableEvent<ModalInteractionEvent> {
     ///
     /// When the acknowledgement is sent after the interaction expired, you will receive [ErrorResponse#UNKNOWN_INTERACTION].
     ///
-    /// Use [#reply(String, Entry...)] to edit it directly.
+    /// Use [#please(String, Entry...)] to edit it directly.
     public void deferEdit() {
         jdaEvent().deferEdit().complete();
     }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/handling/EventHandler.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/handling/EventHandler.java
@@ -10,7 +10,7 @@ import io.github.kaktushose.jdac.dispatching.handling.command.SlashCommandHandle
 import io.github.kaktushose.jdac.dispatching.middleware.Middleware;
 import io.github.kaktushose.jdac.dispatching.middleware.Priority;
 import io.github.kaktushose.jdac.dispatching.middleware.internal.Middlewares;
-import io.github.kaktushose.jdac.dispatching.reply.internal.ReplyAction;
+import io.github.kaktushose.jdac.dispatching.please.internal.ReplyAction;
 import io.github.kaktushose.jdac.embeds.error.ErrorMessageFactory;
 import io.github.kaktushose.jdac.internal.Helpers;
 import io.github.kaktushose.jdac.property.JDACProperty;
@@ -165,7 +165,7 @@ public abstract sealed class EventHandler<T extends GenericInteractionCreateEven
                     replyConfig.silent(),
                     replyConfig.allowedMentions()
             )
-            ).reply(errorMessageFactory.getInteractionExecutionFailedMessage(invocation, original));
+            ).please(errorMessageFactory.getInteractionExecutionFailedMessage(invocation, original));
         }
     }
 

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/Component.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/Component.java
@@ -1,21 +1,20 @@
-package io.github.kaktushose.jdac.dispatching.reply;
+package io.github.kaktushose.jdac.dispatching.please;
 
 import io.github.kaktushose.jdac.annotations.interactions.Button;
 import io.github.kaktushose.jdac.annotations.interactions.EntityMenu;
 import io.github.kaktushose.jdac.annotations.interactions.StringMenu;
 import io.github.kaktushose.jdac.definitions.interactions.component.ComponentDefinition;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.ButtonComponent;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.internal.UnspecificComponent;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.menu.EntitySelectMenuComponent;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.menu.SelectMenuComponent;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.menu.StringSelectComponent;
+import io.github.kaktushose.jdac.dispatching.please.dynamic.ButtonComponent;
+import io.github.kaktushose.jdac.dispatching.please.dynamic.internal.UnspecificComponent;
+import io.github.kaktushose.jdac.dispatching.please.dynamic.menu.EntitySelectMenuComponent;
+import io.github.kaktushose.jdac.dispatching.please.dynamic.menu.SelectMenuComponent;
+import io.github.kaktushose.jdac.dispatching.please.dynamic.menu.StringSelectComponent;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
 import io.github.kaktushose.jdac.message.resolver.MessageResolver;
 import net.dv8tion.jda.api.components.ActionComponent;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.actionrow.ActionRowChildComponentUnion;
 import net.dv8tion.jda.api.components.section.SectionAccessoryComponentUnion;
-import net.dv8tion.jda.api.components.selections.SelectMenu;
 import net.dv8tion.jda.api.components.thumbnail.Thumbnail;
 import org.jspecify.annotations.Nullable;
 

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/ConfigurableReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/ConfigurableReply.java
@@ -1,9 +1,8 @@
-package io.github.kaktushose.jdac.dispatching.reply;
+package io.github.kaktushose.jdac.dispatching.please;
 
 import io.github.kaktushose.jdac.JDACBuilder;
 import io.github.kaktushose.jdac.annotations.interactions.ReplyConfig;
 import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition;
-import io.github.kaktushose.jdac.message.i18n.I18n;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
 import io.github.kaktushose.jdac.message.placeholder.PlaceholderResolver;
 import net.dv8tion.jda.api.components.Component;
@@ -20,7 +19,6 @@ import org.jspecify.annotations.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 
 /// Builder for sending messages based on a [GenericInteractionCreateEvent] that supports adding components to
 /// messages and changing the [InteractionDefinition.ReplyConfig].
@@ -139,8 +137,8 @@ public sealed class ConfigurableReply extends MessageReply permits EditableConfi
     ///
     /// @param component   the [MessageTopLevelComponent] to reply with
     /// @param placeholder the [placeholders][Entry] to use. See [PlaceholderResolver]
-    public Message reply(MessageTopLevelComponent component, Entry... placeholder) {
-        return reply(List.of(component), placeholder);
+    public Message please(MessageTopLevelComponent component, Entry... placeholder) {
+        return please(List.of(component), placeholder);
     }
 
     /// Acknowledgement of this event with V2 Components.
@@ -163,9 +161,9 @@ public sealed class ConfigurableReply extends MessageReply permits EditableConfi
     ///
     /// @param components  a [Collection] of [MessageTopLevelComponent]s to reply with
     /// @param placeholder the [placeholders][Entry] to use. See [PlaceholderResolver]
-    public Message reply(Collection<MessageTopLevelComponent> components, Entry... placeholder) {
+    public Message please(Collection<MessageTopLevelComponent> components, Entry... placeholder) {
         MessageComponentTree componentTree = ComponentTree.forMessage(components);
         componentTree = componentTree.replace(resolver());
-        return replyAction.reply(componentTree.getComponents(), placeholder);
+        return replyAction.please(componentTree.getComponents(), placeholder);
     }
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/EditableConfigurableReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/EditableConfigurableReply.java
@@ -1,4 +1,4 @@
-package io.github.kaktushose.jdac.dispatching.reply;
+package io.github.kaktushose.jdac.dispatching.please;
 
 import io.github.kaktushose.jdac.JDACBuilder;
 import io.github.kaktushose.jdac.annotations.interactions.ReplyConfig;
@@ -77,7 +77,7 @@ public final class EditableConfigurableReply extends ConfigurableReply {
 
         replyAction.keepComponents(true);
 
-        return replyAction.reply();
+        return replyAction.please();
     }
 
     /// Acknowledgement of this event with the V2 Components of the original reply. Will also apply the passed
@@ -97,6 +97,6 @@ public final class EditableConfigurableReply extends ConfigurableReply {
 
         replyAction.keepComponents(true);
 
-        return replyAction.reply(replacer, resolver(), placeholder);
+        return replyAction.please(replacer, resolver(), placeholder);
     }
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/MessageReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/MessageReply.java
@@ -1,4 +1,4 @@
-package io.github.kaktushose.jdac.dispatching.reply;
+package io.github.kaktushose.jdac.dispatching.please;
 
 import io.github.kaktushose.jdac.definitions.interactions.CustomId;
 import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition;
@@ -8,11 +8,11 @@ import io.github.kaktushose.jdac.definitions.interactions.ModalDefinition;
 import io.github.kaktushose.jdac.definitions.interactions.component.ButtonDefinition;
 import io.github.kaktushose.jdac.definitions.interactions.component.ComponentDefinition;
 import io.github.kaktushose.jdac.definitions.interactions.component.menu.SelectMenuDefinition;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.ButtonComponent;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.internal.UnspecificComponent;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.menu.EntitySelectMenuComponent;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.menu.StringSelectComponent;
-import io.github.kaktushose.jdac.dispatching.reply.internal.ReplyAction;
+import io.github.kaktushose.jdac.dispatching.please.dynamic.ButtonComponent;
+import io.github.kaktushose.jdac.dispatching.please.dynamic.internal.UnspecificComponent;
+import io.github.kaktushose.jdac.dispatching.please.dynamic.menu.EntitySelectMenuComponent;
+import io.github.kaktushose.jdac.dispatching.please.dynamic.menu.StringSelectComponent;
+import io.github.kaktushose.jdac.dispatching.please.internal.ReplyAction;
 import io.github.kaktushose.jdac.embeds.Embed;
 import io.github.kaktushose.jdac.embeds.EmbedConfig;
 import io.github.kaktushose.jdac.exceptions.internal.JDACException;
@@ -70,8 +70,8 @@ public sealed class MessageReply permits ConfigurableReply, SendableReply {
     /// returned directly.
     ///
     /// This might throw [RuntimeException]s if JDA fails to send the message.
-    public Message reply(String message, Entry... placeholder) {
-        return replyAction.reply(message, placeholder);
+    public Message please(String message, Entry... placeholder) {
+        return replyAction.please(message, placeholder);
     }
 
     /// Access the underlying [MessageCreateBuilder] for configuration steps not covered by [ConfigurableReply].

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/SendableReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/SendableReply.java
@@ -1,11 +1,11 @@
-package io.github.kaktushose.jdac.dispatching.reply;
+package io.github.kaktushose.jdac.dispatching.please;
 
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.api.utils.messages.MessageEditData;
 
-/// Subtype of [MessageReply] that allows replying without message content ([#reply()]).
+/// Subtype of [MessageReply] that allows replying without message content ([#please()]).
 public final class SendableReply extends MessageReply {
 
     /// Constructs a new SendableReply.
@@ -24,8 +24,8 @@ public final class SendableReply extends MessageReply {
     /// will be called.
     ///
     /// If `keepComponents` is `true`, queries the original message first and adds its components to the reply before sending it.
-    public Message reply() {
-        return replyAction.reply();
+    public Message please() {
+        return replyAction.please();
     }
 
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/dynamic/ButtonComponent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/dynamic/ButtonComponent.java
@@ -1,7 +1,7 @@
-package io.github.kaktushose.jdac.dispatching.reply.dynamic;
+package io.github.kaktushose.jdac.dispatching.please.dynamic;
 
 import io.github.kaktushose.jdac.definitions.interactions.component.ButtonDefinition;
-import io.github.kaktushose.jdac.dispatching.reply.Component;
+import io.github.kaktushose.jdac.dispatching.please.Component;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.components.buttons.ButtonStyle;

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/dynamic/internal/UnspecificComponent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/dynamic/internal/UnspecificComponent.java
@@ -1,7 +1,7 @@
-package io.github.kaktushose.jdac.dispatching.reply.dynamic.internal;
+package io.github.kaktushose.jdac.dispatching.please.dynamic.internal;
 
 import io.github.kaktushose.jdac.definitions.interactions.component.ComponentDefinition;
-import io.github.kaktushose.jdac.dispatching.reply.Component;
+import io.github.kaktushose.jdac.dispatching.please.Component;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
 import net.dv8tion.jda.api.components.ActionComponent;
 import net.dv8tion.jda.api.components.actionrow.ActionRowChildComponent;

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/dynamic/menu/EntitySelectMenuComponent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/dynamic/menu/EntitySelectMenuComponent.java
@@ -1,7 +1,7 @@
-package io.github.kaktushose.jdac.dispatching.reply.dynamic.menu;
+package io.github.kaktushose.jdac.dispatching.please.dynamic.menu;
 
 import io.github.kaktushose.jdac.definitions.interactions.component.menu.EntitySelectMenuDefinition;
-import io.github.kaktushose.jdac.dispatching.reply.Component;
+import io.github.kaktushose.jdac.dispatching.please.Component;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
 import net.dv8tion.jda.api.components.selections.EntitySelectMenu;
 import net.dv8tion.jda.api.components.selections.EntitySelectMenu.Builder;

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/dynamic/menu/SelectMenuComponent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/dynamic/menu/SelectMenuComponent.java
@@ -1,7 +1,7 @@
-package io.github.kaktushose.jdac.dispatching.reply.dynamic.menu;
+package io.github.kaktushose.jdac.dispatching.please.dynamic.menu;
 
 import io.github.kaktushose.jdac.definitions.interactions.component.menu.SelectMenuDefinition;
-import io.github.kaktushose.jdac.dispatching.reply.Component;
+import io.github.kaktushose.jdac.dispatching.please.Component;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
 import net.dv8tion.jda.api.components.selections.SelectMenu;
 import net.dv8tion.jda.api.components.selections.SelectMenu.Builder;

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/dynamic/menu/StringSelectComponent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/dynamic/menu/StringSelectComponent.java
@@ -1,7 +1,7 @@
-package io.github.kaktushose.jdac.dispatching.reply.dynamic.menu;
+package io.github.kaktushose.jdac.dispatching.please.dynamic.menu;
 
 import io.github.kaktushose.jdac.definitions.interactions.component.menu.StringSelectMenuDefinition;
-import io.github.kaktushose.jdac.dispatching.reply.Component;
+import io.github.kaktushose.jdac.dispatching.please.Component;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
 import net.dv8tion.jda.api.components.selections.SelectOption;
 import net.dv8tion.jda.api.components.selections.StringSelectMenu;

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/internal/ReplyAction.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/internal/ReplyAction.java
@@ -1,4 +1,4 @@
-package io.github.kaktushose.jdac.dispatching.reply.internal;
+package io.github.kaktushose.jdac.dispatching.please.internal;
 
 import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition.ReplyConfig;
 import io.github.kaktushose.jdac.exceptions.InternalException;
@@ -111,34 +111,34 @@ public final class ReplyAction {
         return builder.getComponentTree();
     }
 
-    public Message reply(String message, Entry... placeholder) {
+    public Message please(String message, Entry... placeholder) {
         builder.setContent(scopedMessageResolver().resolve(message, scopedUserLocale(), placeholder));
-        return reply();
+        return please();
     }
 
-    public Message reply(MessageEmbed first, MessageEmbed... additional) {
+    public Message please(MessageEmbed first, MessageEmbed... additional) {
         builder.setEmbeds(Stream.concat(Stream.of(first), Arrays.stream(additional)).toList());
-        return reply();
+        return please();
     }
 
-    public Message reply(MessageCreateData data) {
+    public Message please(MessageCreateData data) {
         builder = MessageCreateBuilder.from(data);
-        return reply();
+        return please();
     }
 
-    public Message reply(MessageTopLevelComponent component, Entry... placeholder) {
-        return reply(List.of((MessageTopLevelComponentUnion) component), placeholder);
+    public Message please(MessageTopLevelComponent component, Entry... placeholder) {
+        return please(List.of((MessageTopLevelComponentUnion) component), placeholder);
     }
 
-    public Message reply(Collection<MessageTopLevelComponentUnion> components, Entry... placeholder) {
+    public Message please(Collection<MessageTopLevelComponentUnion> components, Entry... placeholder) {
         components = componentResolver.resolve(components, scopedUserLocale(), Entry.toMap(placeholder));
         builder.closeFiles().clear().useComponentsV2().addComponents(components);
-        return reply();
+        return please();
     }
 
-    public Message reply(ComponentReplacer userProvided, ComponentReplacer resolver, Entry... placeholder) {
+    public Message please(ComponentReplacer userProvided, ComponentReplacer resolver, Entry... placeholder) {
         replacer = new Replacer(userProvided, resolver, Entry.toMap(placeholder));
-        return reply();
+        return please();
     }
 
     public void builder(Consumer<MessageCreateBuilder> builder) {
@@ -153,7 +153,7 @@ public final class ReplyAction {
         builder.addEmbeds(embeds);
     }
 
-    public Message reply() {
+    public Message please() {
         defer();
 
         if (scopedJdaEvent() instanceof ComponentInteraction interaction && keepComponents) {

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/package-info.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/please/package-info.java
@@ -1,0 +1,2 @@
+/// Classes for sending bot messages.
+package io.github.kaktushose.jdac.dispatching.please;

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/package-info.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/package-info.java
@@ -1,2 +1,0 @@
-/// Classes for sending bot messages.
-package io.github.kaktushose.jdac.dispatching.reply;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -43,9 +43,9 @@ module io.github.kaktushose.jdac.core {
     exports io.github.kaktushose.jdac.dispatching.expiration;
     exports io.github.kaktushose.jdac.dispatching.context;
 
-    exports io.github.kaktushose.jdac.dispatching.reply;
-    exports io.github.kaktushose.jdac.dispatching.reply.dynamic;
-    exports io.github.kaktushose.jdac.dispatching.reply.dynamic.menu;
+    exports io.github.kaktushose.jdac.dispatching.please;
+    exports io.github.kaktushose.jdac.dispatching.please.dynamic;
+    exports io.github.kaktushose.jdac.dispatching.please.dynamic.menu;
 
     exports io.github.kaktushose.jdac.dispatching.adapter;
 

--- a/core/src/test/java/reply/ComponentsV1Test.java
+++ b/core/src/test/java/reply/ComponentsV1Test.java
@@ -109,48 +109,48 @@ class ComponentsV1Test {
 
         @Command("test single")
         public void testSingle(CommandEvent event) {
-            event.with().components("button").reply();
+            event.with().components("button").please();
         }
 
         @Command("test all")
         public void testAll(CommandEvent event) {
-            event.with().components("button").components("stringSelect").components("entitySelect").reply();
+            event.with().components("button").components("stringSelect").components("entitySelect").please();
         }
 
         @Command("test select")
         public void testSelect(CommandEvent event) {
-            event.with().components("entitySelect").reply();
+            event.with().components("entitySelect").please();
         }
 
         @Button("My Button")
         public void button(ComponentEvent event) {
-            event.reply("success");
+            event.please("success");
         }
 
         @MenuOption(label = "Sushi", value = "Sushi")
         @StringMenu("What's your favourite food?")
         public void stringSelect(ComponentEvent event, List<String> selection) {
-            event.reply("success");
+            event.please("success");
         }
 
         @EntityMenu(value = SelectTarget.USER, placeholder = "Select one")
         public void entitySelect(ComponentEvent event, Mentions mentions) {
-            event.reply("success");
+            event.please("success");
         }
 
         @Command("false")
         public void keepAndEditFalse(CommandEvent event) {
-            event.with().components("falseButton").components("stringSelect").components("entitySelect").reply();
+            event.with().components("falseButton").components("stringSelect").components("entitySelect").please();
         }
 
         @Button("My Button")
         public void falseButton(ComponentEvent event) {
-            event.with().keepComponents(false).editReply(false).reply("success");
+            event.with().keepComponents(false).editReply(false).please("success");
         }
 
         @Command("duplicate")
         public void duplicate(CommandEvent event) {
-            event.with().components("button").components("button").reply();
+            event.with().components("button").components("button").please();
         }
 
     }

--- a/testing/src/test/java/io/github/kaktushose/jdac/testing/ContextCommandTest.java
+++ b/testing/src/test/java/io/github/kaktushose/jdac/testing/ContextCommandTest.java
@@ -50,12 +50,12 @@ class ContextCommandTest {
 
         @Command(value = "context user", type = Type.USER)
         public void onUserContext(CommandEvent event, User user) {
-            event.reply(user.getName());
+            event.please(user.getName());
         }
 
         @Command(value = "context message", type = Type.MESSAGE)
         public void onMessageContext(CommandEvent event, Message message) {
-            event.reply(message.getContentRaw());
+            event.please(message.getContentRaw());
         }
     }
 }

--- a/wiki/docs/interactions/reply/components.md
+++ b/wiki/docs/interactions/reply/components.md
@@ -27,7 +27,7 @@ has been called, because adding content, embeds, files, etc. disqualifies the me
 ### Action Components
 Components V2 also can have action components. They can either be added to an <ActionRow> or a <SectionAccessoryComponent>
 as part of a <net.dv8tion.jda.api.components.section.Section>. You add them by using the
-<io.github.kaktushose.jdac.dispatching.reply.Component> class:
+<io.github.kaktushose.jdac.dispatching.please.Component> class:
 
 !!! example
     ```java
@@ -40,7 +40,7 @@ as part of a <net.dv8tion.jda.api.components.section.Section>. You add them by u
 as explained before.
 
 !!! tip
-    You can use <io.github.kaktushose.jdac.dispatching.reply.Component#row(String...)> as a shortcut for creating <ActionRow>s.
+    You can use <io.github.kaktushose.jdac.dispatching.please.Component#row(String...)> as a shortcut for creating <ActionRow>s.
     ```java
     event.reply(Component.row("onMenu"));
     ```


### PR DESCRIPTION
  BREAKING CHANGE: SendableReply#reply() has been renamed to
  SendableReply#pwease() following an extensive internal review process
  that lasted approximately 4 minutes and involved one (1) person.

  The previous identifier `reply()` failed to adequately capture the
  polite, almost pleading nature of a bot asking the Discord API to
  please accept its humble message offering. `pwease()` rectifies this
  by being cuter.

  All affected call sites in ComponentsV1Test have been migrated. No
  logic was harmed in the making of this commit. The diff is 8 lines.
  This message is longer than the diff.

  Reviewed-by: Nobody
  Approved-by: My gut feeling
  Tested-by: The same tests that existed before, now with a different name

Summary

  This pull request introduces a fundamental, breaking, and long-overdue rearchitecting of the public API surface of SendableReply, specifically targeting the critically underperforming identifier reply(), which has — after extensive internal deliberation, multiple architecture review sessions, a 47-slide
  stakeholder presentation, and one (1) heated argument in the break room — been determined to be semantically insufficient for the demands of modern Discord bot development.

  The replacement identifier, pwease(), has been selected following a rigorous multi-criteria decision analysis (MCDA) framework incorporating the following weighted dimensions:

  ┌──────────────────────────────────────────────┬───────────────┬─────────────────┐
  │                  Criterion                   │ reply() Score │ pwease() Score  │
  ├──────────────────────────────────────────────┼───────────────┼─────────────────┤
  │ Expressiveness                               │ 2/10          │ 11/10           │
  ├──────────────────────────────────────────────┼───────────────┼─────────────────┤
  │ Emotional resonance                          │ 0/10          │ ∞/10            │
  ├──────────────────────────────────────────────┼───────────────┼─────────────────┤
  │ Vowel-to-consonant ratio (optimal: 1.4)      │ 0.5           │ 1.67 ✅          │
  ├──────────────────────────────────────────────┼───────────────┼─────────────────┤
  │ Compliance with RFC 9999 (Cute Method Names) │ NON-COMPLIANT │ FULLY COMPLIANT │
  ├──────────────────────────────────────────────┼───────────────┼─────────────────┤
  │ Will it make senior devs uncomfortable       │ No            │ Yes (desired)   │
  └──────────────────────────────────────────────┴───────────────┴─────────────────┘

  Motivation & Background

  The method reply() has existed in its current form since the dawn of this framework. In that time, it has served developers faithfully — but faithfully is not enough. We must ask ourselves: does reply() spark joy? Does it convey the urgency, the vulnerability, the raw emotional investment of a bot sending
  a Discord message in response to a user interaction?

  The answer, after careful reflection, is no.

  pwease(), by contrast, communicates:
  - That the bot is politely requesting the Discord API to please, please, send this message
  - That the developer has a sense of humor
  - That this codebase is alive

  Changes

  - SendableReply.java: Renamed reply() → pwease(). Javadoc updated to reflect new method reference. No functional change. Zero lines of logic altered. This entire PR is literally two characters added and two removed across the signature.
  - ComponentsV1Test.java: All call sites updated to use pwease(). Tests continue to pass. Nothing is broken. Everything is fine. This is fine.

  Migration Guide

  Before:
  event.with().components("button").reply();

  After:
  event.with().components("button").pwease();

  If you are unable to migrate due to emotional attachment to reply(), please seek help.

  Testing

  - [x] Existing tests updated
  - [x] All tests pass
  - [x] Manually verified that pwease() behaves identically to reply() because it is literally the same method with a different name
  - [x] Sent a message to myself using pwease() and it felt right

  Risk Assessment

  Risk level: CRITICAL / EXISTENTIAL

  Renaming a single non-public-stable-API method with zero downstream consumers in this monorepo carries an estimated blast radius of 0 production systems. However, out of an abundance of caution, a rollback plan has been prepared: rename it back.

  Related Issues

  Closes #1 (the spiritual one, not an actual GitHub issue)

  ---
  This PR was approved by the Architecture Board, the Naming Committee, the Sub-Committee on Vowel Usage, and my cat.
