### PR TITLE
Fix `@Min` and `@Max` constraints not working and also add missing support for Strings

### DIFF
--- a/core/src/main/java/io/github/kaktushose/jdac/annotations/constraints/Max.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/annotations/constraints/Max.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
 /// @see Constraint
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-@Constraint({Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class})
+@Constraint({Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class, String.class})
 public @interface Max {
 
     /// Returns the value the element must be less or equal to.

--- a/core/src/main/java/io/github/kaktushose/jdac/annotations/constraints/Min.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/annotations/constraints/Min.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
 /// @see Constraint
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-@Constraint({Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class})
+@Constraint({Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class, String.class})
 public @interface Min {
 
     /// Returns the value the element must be greater or equal to.

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/OptionDataDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/OptionDataDefinition.java
@@ -226,8 +226,8 @@ public record OptionDataDefinition(
                                 );
                         case Validators.Result.Success(Validator<?, ?> validator) ->
                                 result.add(new ConstraintDefinition(validator, it));
-                        case Validators.Result.DiscordHandled _ -> {
-                        }
+                        case Validators.Result.DiscordHandled _ ->
+                                result.add(new ConstraintDefinition((_, _, _) -> {}, it));
                     }
                 });
         return result;
@@ -330,11 +330,25 @@ public record OptionDataDefinition(
 
         constraints.stream().filter(constraint ->
                 constraint.annotation().value() instanceof Min
-        ).findFirst().ifPresent(constraint -> optionData.setMinValue(((Min) constraint.annotation().value()).value()));
+        ).findFirst().ifPresent(constraint -> {
+            long value = ((Min) constraint.annotation().value()).value();
+            if (optionData.getType() == OptionType.STRING) {
+                optionData.setMinLength((int) value);
+            } else {
+                optionData.setMinValue(value);
+            }
+        });
 
         constraints.stream().filter(constraint ->
                 constraint.annotation().value() instanceof Max
-        ).findFirst().ifPresent(constraint -> optionData.setMaxValue(((Max) constraint.annotation().value()).value()));
+        ).findFirst().ifPresent(constraint -> {
+            long value = ((Max) constraint.annotation().value()).value();
+            if (optionData.getType() == OptionType.STRING) {
+                optionData.setMaxLength((int) value);
+            } else {
+                optionData.setMaxValue(value);
+            }
+        });
 
         java.util.Optional.ofNullable(CHANNEL_TYPE_RESTRICTIONS.get(declaredType)).ifPresent(optionData::setChannelTypes);
 
@@ -343,12 +357,22 @@ public record OptionDataDefinition(
 
     /// Representation of a parameter constraint defined by a constraint annotation.
     ///
-    /// @param validator  the corresponding [Validator]
-    /// @param annotation the corresponding annotation object
+    /// @param validator      the corresponding [Validator]
+    /// @param annotation     the corresponding annotation object
+    /// @param discordHandled whether this constraint is handled by Discord itself or by JDA-Commands
     public record ConstraintDefinition(
             Validator<?, ?> validator,
-            AnnotationDescription<?> annotation
+            AnnotationDescription<?> annotation,
+            boolean discordHandled
     ) implements Definition {
+
+        /// Representation of a parameter constraint defined by a constraint annotation.
+        ///
+        /// @param validator  the corresponding [Validator]
+        /// @param annotation the corresponding annotation object
+        public ConstraintDefinition(Validator<?, ?> validator, AnnotationDescription<?> annotation) {
+            this(validator, annotation, false);
+        }
 
         @Override
         public String displayName() {

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/middleware/impl/ConstraintMiddleware.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/middleware/impl/ConstraintMiddleware.java
@@ -60,7 +60,7 @@ public class ConstraintMiddleware implements Middleware {
             }
 
             var optionData = commandOptions.get(i);
-            for (var constraint : optionData.constraints()) {
+            for (var constraint : optionData.constraints().stream().filter(it -> !it.discordHandled()).toList()) {
                 log.debug("Found constraint {} for parameter {}", constraint, optionData.declaredType().getName());
                 Validator<Object, Annotation> validator = (Validator<Object, Annotation>) constraint.validator();
 

--- a/core/src/test/java/definitions/interactions/options/OptionDataTest.java
+++ b/core/src/test/java/definitions/interactions/options/OptionDataTest.java
@@ -1,5 +1,7 @@
 package definitions.interactions.options;
 
+import io.github.kaktushose.jdac.annotations.constraints.Max;
+import io.github.kaktushose.jdac.annotations.constraints.Min;
 import io.github.kaktushose.jdac.annotations.interactions.Choices;
 import io.github.kaktushose.jdac.annotations.interactions.Command;
 import io.github.kaktushose.jdac.annotations.interactions.Interaction;
@@ -202,6 +204,18 @@ class OptionDataTest {
         assertEquals("camel_case", optionData("camelCase").name());
     }
 
+    @Test
+    void optionData_withMinMax_shouldRegisterAtDiscord() {
+        var optionData = optionData("minMaxString").toJDAEntity();
+        assertEquals(2, optionData.getMinLength());
+        assertEquals(4, optionData.getMaxLength());
+
+        optionData = optionData("minMaxInt").toJDAEntity();
+        assertEquals(2L, optionData.getMinValue());
+        assertEquals(4L, optionData.getMaxValue());
+
+    }
+
     private ParameterDescription modify(Class<?> type, ParameterDescription description) {
         return new ParameterDescription(type, description.typeArguments(), description.name(), description.annotations());
     }
@@ -295,6 +309,14 @@ class OptionDataTest {
         @Command("providerCombined")
         public void providerCombined(CommandEvent event, @Choices(value = "Foo",
                 provider = "correctProvider") String option) {
+        }
+
+        @Command("minMaxString")
+        public void minMaxString(CommandEvent event, @Min(2) @Max(4) String option) {
+        }
+
+        @Command("minMaxInt")
+        public void minMaxInt(CommandEvent event, @Min(2) @Max(4) int option) {
         }
 
         private List<String> privateProvider() {

--- a/core/src/test/java/definitions/interactions/options/ValidatorTest.java
+++ b/core/src/test/java/definitions/interactions/options/ValidatorTest.java
@@ -90,7 +90,7 @@ class ValidatorTest {
         }
 
         @Command("minMaxWrongType")
-        public void minMaxWrongType(CommandEvent event, @Min(1) String min, @Max(1) String max) {
+        public void minMaxWrongType(CommandEvent event, @Min(1) Object min, @Max(1) Object max) {
         }
 
         @Command("noValidator")

--- a/wiki/docs/interactions/commands/slash.md
+++ b/wiki/docs/interactions/commands/slash.md
@@ -162,11 +162,11 @@ public void onBanMember(CommandEvent event, Member target, Optional<String> reas
     Required options must be added before non-required options.
 
 ### Min & Max Value
-Use the <Min> or <Max> annotation to set the minimum and maximum value for numeral options.
+Use the <Min> or <Max> annotation to set the minimum and maximum value for numeral options or for Strings.
 !!! example
     ```java
     @Command("ban")
-    public void onBanMember(CommandEvent event, Member target, String reason, @Max(7) int delDays) {
+    public void onBanMember(CommandEvent event, Member target, @Min(10) String reason, @Max(7) int delDays) {
         (...)
     }
     ```


### PR DESCRIPTION
## Type
- [ ] Feature
- [x] Fix
- [ ] Refactor

closes #362 

## Description
Fixes that the `@Min` and `@Max` constraints weren't registered at Discord and also fixes the missing support for Strings.

### Example
<!-- only fill out for feature prs -->
```java
@Command("info")
public void onCommand(CommandEvent event, @Min(2) @Max(19) String value) {
    ...
}
```

## Checklist

- [x] Applied IntelliJ Formatter (`Ctrl` + `Shift` + `L`)
- [x] Applied `gradle format`
- [x] If applicable, added unit tests
- [x] Updated documentation
