### PR TITLE
Fix description always being overridden by LocalizationFunction

### DIFF
--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/SlashCommandDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/SlashCommandDefinition.java
@@ -11,6 +11,8 @@ import io.github.kaktushose.jdac.dispatching.events.interactions.CommandEvent;
 import io.github.kaktushose.jdac.exceptions.InvalidDeclarationException;
 import io.github.kaktushose.jdac.exceptions.internal.JDACException;
 import io.github.kaktushose.jdac.internal.Helpers;
+import io.github.kaktushose.jdac.property.JDACProperty;
+import net.dv8tion.jda.api.interactions.DiscordLocale;
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
@@ -122,7 +124,8 @@ public record SlashCommandDefinition(
 
     /// Transforms this definition into [SlashCommandData].
     ///
-    /// This does not set [CommandData#setLocalizationFunction(LocalizationFunction)]!
+    /// This does not set [CommandData#setLocalizationFunction(LocalizationFunction)]! However, if no description is
+    /// provided, will set all available locales with the default message (`jdac$no-description`) from the `jdac` bundle.
     ///
     /// @return the [SlashCommandData]
     @Override
@@ -142,6 +145,19 @@ public record SlashCommandDefinition(
                             .map(OptionDataDefinition::toJDAEntity)
                             .toList()
                     );
+
+            if (description.isBlank()) {
+                Map<DiscordLocale, String> localizations = new HashMap<>();
+                for (DiscordLocale locale : DiscordLocale.values()) {
+                    if (locale == DiscordLocale.UNKNOWN) {
+                        continue;
+                    }
+                    String result = JDACProperty.MESSAGE_RESOLVER.scopedGet().resolve("jdac$no-description", locale);
+                    localizations.put(locale, result);
+                }
+                command.setDescriptionLocalizations(localizations);
+            }
+
             return command;
         } catch (IllegalArgumentException e) {
             throw Helpers.jdaException(e, this);

--- a/core/src/main/java/io/github/kaktushose/jdac/message/i18n/internal/JDACLocalizationFunction.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/message/i18n/internal/JDACLocalizationFunction.java
@@ -94,18 +94,10 @@ public final class JDACLocalizationFunction implements LocalizationFunction {
             }
 
             tryLocalize(bundle + "$" + localizationKey, locale) // with found bundle (or default)
-                    .or(() -> tryLocalize(localizationKey, locale)) // fallback to default bundle if not found in special bundle
-                    .or(() -> {
-                        if (localizationKey.endsWith(".description")) {
-                            String result = resolver.resolve("jdac$no-description", locale);
-                            return Optional.of(result);
-                        }
-
-                        missingLocalizations.computeIfAbsent(localizationKey, _ -> new HashSet<>()).add(locale);
-
-                        return Optional.empty();
-                    })
-                    .ifPresent(s -> localizations.put(locale, s));
+                    .or(() -> tryLocalize(localizationKey, locale))
+                    .ifPresentOrElse(s -> localizations.put(locale, s), () ->
+                            missingLocalizations.computeIfAbsent(localizationKey, _ -> new HashSet<>()).add(locale)
+                    );
         }
 
         return localizations;

--- a/core/src/test/java/definitions/interactions/SlashCommandDefinitionTest.java
+++ b/core/src/test/java/definitions/interactions/SlashCommandDefinitionTest.java
@@ -94,18 +94,21 @@ class SlashCommandDefinitionTest {
 
     @Test
     public void test() {
-        SlashCommandData command = build("correct").toJDAEntity();
         JDACIntrospectionImpl jdacIntrospection = JDACIntrospectionImpl
                 .create(JDACScope.INITIALIZED)
                 .addFallback(JDACInternalProperties.BUNDLE_FINDER, _ -> new BundleFinder(Descriptor.REFLECTIVE))
                 .addFallback(JDACProperty.DEFINITIONS, _ -> new InteractionRegistry(null, null, null))
                 .addFallback(JDACProperty.MESSAGE_RESOLVER, _ -> new MessageResolver(List.of()))
                 .build();
-        command.setLocalizationFunction(JDACLocalizationFunction.PROVIDER_FUNC.apply(jdacIntrospection));
+        jdacIntrospection.scoped().run(() -> {
+            SlashCommandData command = build("noDescription").toJDAEntity();
+            command.setLocalizationFunction(JDACLocalizationFunction.PROVIDER_FUNC.apply(jdacIntrospection));
 
-        DataObject data = command.toData();
+            DataObject data = command.toData();
 
-
+            assertEquals("no description", data.getString("description"));
+            assertTrue(data.getObject("description_localizations").keys().isEmpty());
+        });
     }
 
     private SlashCommandDefinition build(String method) {
@@ -153,7 +156,7 @@ class SlashCommandDefinitionTest {
         public void correct(CommandEvent event, String option) {
         }
 
-        @Command(value = "noDescription")
+        @Command(value = "nodescription")
         public void noDescription(CommandEvent event) {
         }
 

--- a/core/src/test/java/definitions/interactions/SlashCommandDefinitionTest.java
+++ b/core/src/test/java/definitions/interactions/SlashCommandDefinitionTest.java
@@ -2,22 +2,32 @@ package definitions.interactions;
 
 import io.github.kaktushose.jdac.annotations.interactions.Command;
 import io.github.kaktushose.jdac.annotations.interactions.Interaction;
+import io.github.kaktushose.jdac.definitions.description.Descriptor;
+import io.github.kaktushose.jdac.definitions.interactions.InteractionRegistry;
 import io.github.kaktushose.jdac.definitions.interactions.command.SlashCommandDefinition;
 import io.github.kaktushose.jdac.dispatching.events.ReplyableEvent;
 import io.github.kaktushose.jdac.dispatching.events.interactions.CommandEvent;
 import io.github.kaktushose.jdac.exceptions.InvalidDeclarationException;
+import io.github.kaktushose.jdac.message.i18n.internal.BundleFinder;
+import io.github.kaktushose.jdac.message.i18n.internal.JDACLocalizationFunction;
+import io.github.kaktushose.jdac.message.resolver.MessageResolver;
+import io.github.kaktushose.jdac.property.Definitions;
+import io.github.kaktushose.jdac.property.JDACProperty;
+import io.github.kaktushose.jdac.property.JDACScope;
+import io.github.kaktushose.jdac.property.internal.JDACInternalProperties;
 import io.github.kaktushose.jdac.property.internal.JDACIntrospectionImpl;
 import net.dv8tion.jda.api.interactions.commands.Command.Type;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import definitions.TestHelpers;
+import net.dv8tion.jda.api.utils.data.DataObject;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import static definitions.TestHelpers.getBuildContext;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SlashCommandDefinitionTest {
 
@@ -69,7 +79,6 @@ class SlashCommandDefinitionTest {
         assertEquals("description", command.getDescription());
         assertEquals(1, command.getOptions().size());
         assertEquals(Type.SLASH, command.getType());
-
     }
 
     @Test
@@ -81,6 +90,22 @@ class SlashCommandDefinitionTest {
         assertEquals(name, command.getName());
         assertEquals("description", command.getDescription());
         assertEquals(1, command.getOptions().size());
+    }
+
+    @Test
+    public void test() {
+        SlashCommandData command = build("correct").toJDAEntity();
+        JDACIntrospectionImpl jdacIntrospection = JDACIntrospectionImpl
+                .create(JDACScope.INITIALIZED)
+                .addFallback(JDACInternalProperties.BUNDLE_FINDER, _ -> new BundleFinder(Descriptor.REFLECTIVE))
+                .addFallback(JDACProperty.DEFINITIONS, _ -> new InteractionRegistry(null, null, null))
+                .addFallback(JDACProperty.MESSAGE_RESOLVER, _ -> new MessageResolver(List.of()))
+                .build();
+        command.setLocalizationFunction(JDACLocalizationFunction.PROVIDER_FUNC.apply(jdacIntrospection));
+
+        DataObject data = command.toData();
+
+
     }
 
     private SlashCommandDefinition build(String method) {
@@ -127,5 +152,10 @@ class SlashCommandDefinitionTest {
         @Command(value = "correct", desc = "description")
         public void correct(CommandEvent event, String option) {
         }
+
+        @Command(value = "noDescription")
+        public void noDescription(CommandEvent event) {
+        }
+
     }
 }


### PR DESCRIPTION
## Type
- [ ] Feature
- [x] Fix
- [ ] Refactor

closes #363 

## Description
Fixes that the description is always overriden by our LocalizationFunction by moving the fallback string logic from the LocalizationFunction to the SlashCommandDefinition

### Example
<!-- only fill out for feature prs -->
```java
// N/A
```

## Checklist

- [x] Applied IntelliJ Formatter (`Ctrl` + `Shift` + `L`)
- [x] Applied `gradle format`
- [x] If applicable, added unit tests
- [x] Updated documentation
