### PR TITLE
Introduce `@UnstableApi` annotation

### DIFF
--- a/core/src/main/java/io/github/kaktushose/jdac/annotations/UnstableApi.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/annotations/UnstableApi.java
@@ -1,0 +1,16 @@
+package io.github.kaktushose.jdac.annotations;
+
+import java.lang.annotation.*;
+
+/// Marks a public API element as unstable.
+///
+/// Elements annotated with [UnstableApi] are part of the public API because they are required for advanced use cases
+/// or framework integration. However, they are **not** covered by JDA-Commands' semantic versioning compatibility
+/// guarantees.
+///
+/// An unstable API may change, be redesigned, or be removed in a minor release, without a major version bump or further
+/// notice. This allows the API to evolve alongside changes in Discord and JDA.
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.FIELD, ElementType.TYPE, ElementType.METHOD})
+public @interface UnstableApi { }

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/AutoCompleteDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/AutoCompleteDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.annotations.interactions.AutoComplete;
 import io.github.kaktushose.jdac.definitions.description.ClassDescription;
 import io.github.kaktushose.jdac.definitions.description.MethodDescription;
@@ -14,6 +15,7 @@ import java.util.stream.Collectors;
 /// @param classDescription  the [ClassDescription] of the declaring class of the [#methodDescription()]
 /// @param methodDescription the [MethodDescription] of the method this definition is bound to
 /// @param rules             the rules this autocomplete handler can handle
+@UnstableApi
 public record AutoCompleteDefinition(
         ClassDescription classDescription,
         MethodDescription methodDescription,

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/InteractionRegistry.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/InteractionRegistry.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.annotations.interactions.*;
 import io.github.kaktushose.jdac.definitions.Definition;
 import io.github.kaktushose.jdac.definitions.description.ClassDescription;
@@ -24,6 +25,7 @@ import java.util.*;
 import java.util.function.Predicate;
 
 /// Central registry for all [InteractionDefinition]s.
+@UnstableApi
 public record InteractionRegistry(
         Validators validators,
         MessageResolver messageResolver,

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/ModalDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/ModalDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.definitions.description.ClassDescription;
 import io.github.kaktushose.jdac.definitions.description.MethodDescription;
 import io.github.kaktushose.jdac.definitions.features.CustomIdJDAEntity;
@@ -21,6 +22,7 @@ import java.util.Optional;
 /// @param permissions       a [Collection] of permissions for this modal
 /// @param title             the title of the modal
 /// @param components        a [Collection] of [ModalTopLevelComponent]s that will be added to this modal
+@UnstableApi
 public record ModalDefinition(
         ClassDescription classDescription,
         MethodDescription methodDescription,

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/CommandDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/CommandDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions.command;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.annotations.interactions.CommandScope;
 import io.github.kaktushose.jdac.definitions.features.JDAEntity;
 import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition;
@@ -19,6 +20,7 @@ import java.util.function.Consumer;
 ///
 /// @see SlashCommandDefinition
 /// @see ContextCommandDefinition
+@UnstableApi
 public sealed interface CommandDefinition extends InteractionDefinition, JDAEntity<CommandData> permits ContextCommandDefinition, SlashCommandDefinition {
 
     /// The name of the command.

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/ContextCommandDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/ContextCommandDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions.command;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.definitions.description.ClassDescription;
 import io.github.kaktushose.jdac.definitions.description.MethodDescription;
 import io.github.kaktushose.jdac.definitions.interactions.MethodBuildContext;
@@ -27,6 +28,7 @@ import java.util.Optional;
 /// @param name              the name of the command
 /// @param commandType       the [Command.Type] of this command
 /// @param commandConfig     the [CommandConfig] to use
+@UnstableApi
 public record ContextCommandDefinition(
         ClassDescription classDescription,
         MethodDescription methodDescription,

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/OptionDataDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/OptionDataDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions.command;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.annotations.constraints.Constraint;
 import io.github.kaktushose.jdac.annotations.constraints.Max;
 import io.github.kaktushose.jdac.annotations.constraints.Min;
@@ -59,6 +60,7 @@ import static java.util.Map.entry;
 /// @param description  the description of the command option
 /// @param choices      a [SequencedCollection] of possible [Choice]s for this command option
 /// @param constraints  a [Collection] of [ConstraintDefinition]s of this command option
+@UnstableApi
 public record OptionDataDefinition(
         Class<?> declaredType,
         Class<?> resolvedType,

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/SlashCommandDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/command/SlashCommandDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions.command;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.annotations.interactions.Command;
 import io.github.kaktushose.jdac.definitions.description.ClassDescription;
 import io.github.kaktushose.jdac.definitions.description.MethodDescription;
@@ -33,6 +34,7 @@ import static io.github.kaktushose.jdac.message.placeholder.Entry.entry;
 /// @param commandConfig     the [CommandConfig] to use
 /// @param description       the command description
 /// @param commandOptions    a [SequencedCollection] of [OptionDataDefinition]s
+@UnstableApi
 public record SlashCommandDefinition(
         ClassDescription classDescription,
         MethodDescription methodDescription,

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/ButtonDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/ButtonDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions.component;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.definitions.description.ClassDescription;
 import io.github.kaktushose.jdac.definitions.description.MethodDescription;
 import io.github.kaktushose.jdac.definitions.interactions.CustomId;
@@ -28,6 +29,7 @@ import static io.github.kaktushose.jdac.definitions.interactions.component.Compo
 /// @param link              the link of this button or `null`
 /// @param style             the [ButtonStyle] of this button
 /// @param uniqueId          the uniqueId of this button
+@UnstableApi
 public record ButtonDefinition(
         ClassDescription classDescription,
         MethodDescription methodDescription,

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/ComponentDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/ComponentDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions.component;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.definitions.description.ClassDescription;
 import io.github.kaktushose.jdac.definitions.description.MethodDescription;
 import io.github.kaktushose.jdac.definitions.features.CustomIdJDAEntity;
@@ -18,6 +19,7 @@ import java.util.function.Supplier;
 /// @see ButtonDefinition
 /// @see EntitySelectMenuDefinition
 /// @see StringSelectMenuDefinition
+@UnstableApi
 public sealed interface ComponentDefinition<T> extends InteractionDefinition, JDAEntity<T>, CustomIdJDAEntity<T>
         permits ButtonDefinition, SelectMenuDefinition {
 

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/EntitySelectMenuDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/EntitySelectMenuDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions.component.menu;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.annotations.interactions.EntityMenu;
 import io.github.kaktushose.jdac.definitions.description.ClassDescription;
 import io.github.kaktushose.jdac.definitions.description.MethodDescription;
@@ -30,6 +31,7 @@ import static io.github.kaktushose.jdac.definitions.interactions.component.Compo
 /// @param minValue          the minimum amount of choices
 /// @param maxValue          the maximum amount of choices
 /// @param uniqueId          the uniqueId of this menu
+@UnstableApi
 public record EntitySelectMenuDefinition(
         ClassDescription classDescription,
         MethodDescription methodDescription,

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/SelectMenuDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/SelectMenuDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions.component.menu;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.definitions.interactions.component.ComponentDefinition;
 import net.dv8tion.jda.api.components.selections.SelectMenu;
 
@@ -7,6 +8,7 @@ import net.dv8tion.jda.api.components.selections.SelectMenu;
 ///
 /// @see EntitySelectMenuDefinition
 /// @see StringSelectMenuDefinition
+@UnstableApi
 public sealed interface SelectMenuDefinition<T extends SelectMenu> extends ComponentDefinition<T>
         permits EntitySelectMenuDefinition, StringSelectMenuDefinition {
 

--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/StringSelectMenuDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/component/menu/StringSelectMenuDefinition.java
@@ -1,5 +1,6 @@
 package io.github.kaktushose.jdac.definitions.interactions.component.menu;
 
+import io.github.kaktushose.jdac.annotations.UnstableApi;
 import io.github.kaktushose.jdac.annotations.interactions.MenuOption;
 import io.github.kaktushose.jdac.annotations.interactions.MenuOptionContainer;
 import io.github.kaktushose.jdac.annotations.interactions.StringMenu;
@@ -32,6 +33,7 @@ import static io.github.kaktushose.jdac.message.placeholder.Entry.entry;
 /// @param minValue          the minimum amount of choices
 /// @param maxValue          the maximum amount of choices
 /// @param uniqueId          the uniqueId of this menu
+@UnstableApi
 public record StringSelectMenuDefinition(
         ClassDescription classDescription,
         MethodDescription methodDescription,


### PR DESCRIPTION
## Type
- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [x] Documentation

closes #349 

## Description
Introduces an annotation to inform the developer that the interaction defintions have an unstable api that may break in minor version bumps.

### Example
<!-- only fill out for feature prs -->
```java
@UnstableApi
public record SlashCommandDefinition(...)
```

## Checklist

- [x] Applied IntelliJ Formatter (`Ctrl` + `Shift` + `L`)
- [x] Applied `gradle format`
- [ ] If applicable, added unit tests
- [x] Updated documentation
