### PR TITLE
Fix action components in modals not working

### DIFF
--- a/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/ModalDefinition.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/definitions/interactions/ModalDefinition.java
@@ -28,7 +28,7 @@ public record ModalDefinition(
         MethodDescription methodDescription,
         Collection<String> permissions,
         String title,
-        Collection<ModalTopLevelComponent> components
+        Collection<? extends ModalTopLevelComponent> components
 ) implements InteractionDefinition, CustomIdJDAEntity<Modal> {
 
     /// Builds a new [ModalDefinition] from the given [MethodBuildContext].
@@ -44,7 +44,7 @@ public record ModalDefinition(
     }
 
     /// Builds a new [ModalDefinition] with the given values.
-    public ModalDefinition with(@Nullable String title, @Nullable Collection<ModalTopLevelComponent> components) {
+    public ModalDefinition with(@Nullable String title, @Nullable Collection<? extends ModalTopLevelComponent> components) {
         return new ModalDefinition(
                 classDescription,
                 methodDescription,

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/ModalReplyableEvent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/events/ModalReplyableEvent.java
@@ -1,28 +1,17 @@
 package io.github.kaktushose.jdac.dispatching.events;
 
 import io.github.kaktushose.jdac.annotations.interactions.Modal;
-import io.github.kaktushose.jdac.definitions.interactions.CustomId;
-import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition;
-import io.github.kaktushose.jdac.definitions.interactions.ModalDefinition;
 import io.github.kaktushose.jdac.dispatching.events.interactions.CommandEvent;
 import io.github.kaktushose.jdac.dispatching.events.interactions.ComponentEvent;
-import io.github.kaktushose.jdac.exceptions.InternalException;
-import io.github.kaktushose.jdac.internal.logging.JDACLogger;
+import io.github.kaktushose.jdac.dispatching.reply.ModalReply;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
-import io.github.kaktushose.jdac.message.resolver.ComponentResolver;
 import io.github.kaktushose.jdac.message.resolver.MessageResolver;
 import net.dv8tion.jda.api.components.ModalTopLevelComponent;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
-import net.dv8tion.jda.api.interactions.callbacks.IModalCallback;
-import net.dv8tion.jda.internal.utils.Checks;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
 
 import java.util.Collection;
 import java.util.List;
-
-import static io.github.kaktushose.jdac.message.placeholder.Entry.entry;
-import static io.github.kaktushose.jdac.property.internal.IntrospectionAccess.*;
 
 /// Subtype of [ReplyableEvent] that also supports replying with a [Modal].
 ///
@@ -32,9 +21,6 @@ import static io.github.kaktushose.jdac.property.internal.IntrospectionAccess.*;
 public abstract sealed class ModalReplyableEvent<T extends GenericInteractionCreateEvent>
         extends ReplyableEvent<T>
         permits CommandEvent, ComponentEvent {
-
-    private static final Logger log = JDACLogger.getLogger(ModalReplyableEvent.class);
-
 
     /// Acknowledgement of this event with a [Modal]. This will open a popup on the target users Discord client.
     ///
@@ -79,28 +65,6 @@ public abstract sealed class ModalReplyableEvent<T extends GenericInteractionCre
     }
 
     private void reply(@Nullable Class<?> origin, String modal, Collection<ModalTopLevelComponent> components, Entry... placeholders) {
-        if (!(jdaEvent() instanceof IModalCallback callback)) {
-            throw new InternalException("reply-failed", entry("event", jdaEvent().getClass().getName()));
-        }
-        Checks.notEmpty(components, "Modal components");
-
-        InteractionDefinition definition = scopedInvocationContext().definition();
-        String className = origin == null ? definition.classDescription().name() : origin.getName();
-        String definitionId = InteractionDefinition.createDefinitionId(className, modal);
-        ModalDefinition modalDefinition = scopedInteractionRegistry().find(
-                ModalDefinition.class,
-                false,
-                it -> it.definitionId().equals(definitionId)
-        );
-
-        var entryMap = Entry.toMap(placeholders);
-        ComponentResolver<ModalTopLevelComponent> resolver = new ComponentResolver<>(scopedMessageResolver(), ModalTopLevelComponent.class);
-        modalDefinition = modalDefinition.with(
-                scopedMessageResolver().resolve(modalDefinition.title(), scopedUserLocale(), entryMap),
-                resolver.resolve(components, scopedUserLocale(), entryMap)
-        );
-
-        log.debug("Replying to interaction \"{}\" with Modal: \"{}\". [Runtime={}]", definition.displayName(), modalDefinition.displayName(), runtimeId());
-        callback.replyModal(modalDefinition.toJDAEntity(new CustomId(runtimeId(), definitionId))).complete();
+        new ModalReply().reply(origin, modal, components, placeholders);
     }
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/ActionComponentResolver.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/ActionComponentResolver.java
@@ -1,0 +1,101 @@
+package io.github.kaktushose.jdac.dispatching.reply;
+
+import io.github.kaktushose.jdac.definitions.interactions.CustomId;
+import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition;
+import io.github.kaktushose.jdac.definitions.interactions.InteractionRegistry;
+import io.github.kaktushose.jdac.definitions.interactions.ModalDefinition;
+import io.github.kaktushose.jdac.definitions.interactions.component.ButtonDefinition;
+import io.github.kaktushose.jdac.definitions.interactions.component.ComponentDefinition;
+import io.github.kaktushose.jdac.definitions.interactions.component.menu.SelectMenuDefinition;
+import io.github.kaktushose.jdac.dispatching.reply.dynamic.ButtonComponent;
+import io.github.kaktushose.jdac.dispatching.reply.dynamic.internal.UnspecificComponent;
+import io.github.kaktushose.jdac.dispatching.reply.dynamic.menu.EntitySelectMenuComponent;
+import io.github.kaktushose.jdac.dispatching.reply.dynamic.menu.StringSelectComponent;
+import io.github.kaktushose.jdac.exceptions.internal.JDACException;
+import io.github.kaktushose.jdac.internal.logging.JDACLogger;
+import io.github.kaktushose.jdac.message.resolver.ComponentResolver;
+import net.dv8tion.jda.api.components.actionrow.ActionRowChildComponent;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.components.replacer.ComponentReplacer;
+import net.dv8tion.jda.api.components.selections.EntitySelectMenu;
+import net.dv8tion.jda.api.components.selections.StringSelectMenu;
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import static io.github.kaktushose.jdac.message.placeholder.Entry.entry;
+import static io.github.kaktushose.jdac.property.internal.IntrospectionAccess.*;
+
+sealed class ActionComponentResolver permits MessageReply, ModalReply {
+
+    private static final Logger log = JDACLogger.getLogger(ActionComponentResolver.class);
+    private final ComponentResolver<ActionRowChildComponent> resolver;
+
+    protected ActionComponentResolver() {
+        this.resolver = new ComponentResolver<>(scopedMessageResolver(), ActionRowChildComponent.class);
+    }
+
+    protected ComponentReplacer resolver() {
+        return ComponentReplacer.of(Component.class, _ -> true, this::resolveActionComponent);
+    }
+
+    protected ActionRowChildComponent resolveActionComponent(Component<?, ?, ?, ?> component) {
+        var className = component.origin().map(Class::getName)
+                .orElseGet(() -> scopedInvocationContext().definition().methodDescription().declaringClass().getName());
+        String definitionId = InteractionDefinition.createDefinitionId(className, component.name());
+
+        var definition = findDefinition(component, definitionId, className);
+
+        int uniqueId = Objects.requireNonNullElse(definition.uniqueId(), -1);
+        ActionRowChildComponent item = switch (definition) {
+            case ButtonDefinition buttonDefinition ->
+                    buttonDefinition.toJDAEntity(createId(definition, component.independent())).withDisabled(!component.enabled());
+            case SelectMenuDefinition<?> menuDefinition ->
+                    menuDefinition.toJDAEntity(createId(definition, component.independent())).withDisabled(!component.enabled());
+        };
+
+        item = switch (component) {
+            case ButtonComponent buttonComponent -> buttonComponent.callback().apply((Button) item);
+            case EntitySelectMenuComponent entitySelectMenuComponent ->
+                    entitySelectMenuComponent.callback().apply(((EntitySelectMenu) item).createCopy()).build();
+            case StringSelectComponent stringSelectComponent ->
+                    stringSelectComponent.callback().apply(((StringSelectMenu) item).createCopy()).build();
+            case UnspecificComponent unspecificComponent -> unspecificComponent.callback().apply(item);
+        };
+
+        if (uniqueId > 0) {
+            item = item.withUniqueId(uniqueId);
+        }
+        item = resolver.resolve(item, scopedUserLocale(), component.placeholder());
+        log.debug("Reply Debug: Adding component \"{}\" to the reply", definition.displayName());
+        return item;
+    }
+
+    private <D extends ComponentDefinition<?>, T extends Component<T, ?, ?, D>> D findDefinition(Component<T, ?, ?, D> component, String definitionId, String className) {
+        InteractionRegistry registry = scopedInteractionRegistry();
+
+        try {
+            // this cast is effective safe
+            D definition = registry.find(component.definitionClass(), false, it ->
+                    it.definitionId().equals(definitionId)
+            );
+
+            return component.build(definition);
+        } catch (IllegalArgumentException e) { // only check if search failed
+            Collection<ModalDefinition> found = registry.find(ModalDefinition.class, it -> it.definitionId().equals(definitionId));
+            if (!found.isEmpty()) {
+                throw new IllegalArgumentException(
+                        JDACException.errorMessage("modal-as-component", entry("method", "%s#%s".formatted(className, component.name())))
+                );
+            }
+            throw e;
+        }
+    }
+
+    private CustomId createId(InteractionDefinition definition, boolean independent) {
+        return independent
+                ? CustomId.independent(definition.definitionId())
+                : new CustomId(scopedRuntime().id(), definition.definitionId());
+    }
+}

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/MessageReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/MessageReply.java
@@ -1,56 +1,36 @@
 package io.github.kaktushose.jdac.dispatching.reply;
 
-import io.github.kaktushose.jdac.definitions.interactions.CustomId;
-import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition;
 import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition.ReplyConfig;
-import io.github.kaktushose.jdac.definitions.interactions.InteractionRegistry;
-import io.github.kaktushose.jdac.definitions.interactions.ModalDefinition;
-import io.github.kaktushose.jdac.definitions.interactions.component.ButtonDefinition;
-import io.github.kaktushose.jdac.definitions.interactions.component.ComponentDefinition;
-import io.github.kaktushose.jdac.definitions.interactions.component.menu.SelectMenuDefinition;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.ButtonComponent;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.internal.UnspecificComponent;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.menu.EntitySelectMenuComponent;
-import io.github.kaktushose.jdac.dispatching.reply.dynamic.menu.StringSelectComponent;
 import io.github.kaktushose.jdac.dispatching.reply.internal.ReplyAction;
 import io.github.kaktushose.jdac.embeds.Embed;
 import io.github.kaktushose.jdac.embeds.EmbedConfig;
-import io.github.kaktushose.jdac.exceptions.internal.JDACException;
-import io.github.kaktushose.jdac.internal.logging.JDACLogger;
 import io.github.kaktushose.jdac.message.i18n.I18n;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
-import io.github.kaktushose.jdac.message.resolver.ComponentResolver;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.actionrow.ActionRowChildComponent;
-import net.dv8tion.jda.api.components.buttons.Button;
-import net.dv8tion.jda.api.components.replacer.ComponentReplacer;
-import net.dv8tion.jda.api.components.selections.EntitySelectMenu;
-import net.dv8tion.jda.api.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
-import org.slf4j.Logger;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 import java.util.function.Consumer;
 
-import static io.github.kaktushose.jdac.message.placeholder.Entry.entry;
-import static io.github.kaktushose.jdac.property.internal.IntrospectionAccess.*;
+import static io.github.kaktushose.jdac.property.internal.IntrospectionAccess.scopedEmbeds;
+import static io.github.kaktushose.jdac.property.internal.IntrospectionAccess.scopedUserLocale;
 
 /// Handles all the business logic for sending messages, including embeds or V1 components.
-public sealed class MessageReply permits ConfigurableReply, SendableReply {
+public sealed class MessageReply extends ActionComponentResolver permits ConfigurableReply, SendableReply {
 
-    private static final Logger log = JDACLogger.getLogger(MessageReply.class);
     protected final ReplyAction replyAction;
-    private final ComponentResolver<ActionRowChildComponent> resolver;
 
     /// Constructs a new MessageReply.
     ///
     /// @param replyConfig the [ReplyConfig] to use
     public MessageReply(ReplyConfig replyConfig) {
         replyAction = new ReplyAction(replyConfig);
-        resolver = new ComponentResolver<>(scopedMessageResolver(), ActionRowChildComponent.class);
     }
 
     /// Constructs a new MessageReply.
@@ -58,13 +38,12 @@ public sealed class MessageReply permits ConfigurableReply, SendableReply {
     /// @param reply the [MessageReply] to copy from
     public MessageReply(MessageReply reply) {
         replyAction = reply.replyAction;
-        resolver = new ComponentResolver<>(scopedMessageResolver(), ActionRowChildComponent.class);
     }
 
     /// Acknowledgement of this event with a text message.
     ///
     /// @param message     the message to send or the localization key
-    /// @param placeholder the placeholders to use to perform localization, see [I18n#localize(Locale , String, Entry...) ]
+    /// @param placeholder the placeholders to use to perform localization, see [I18n#resolve(Object, Locale, Entry...)]
     /// @return the [Message] that got created
     /// @implSpec Internally this method must call [RestAction#complete()], thus the [Message] object can get
     /// returned directly.
@@ -191,73 +170,10 @@ public sealed class MessageReply permits ConfigurableReply, SendableReply {
     ///
     /// @see Component
     public SendableReply components(Component<?, ?, ?, ?>... components) {
-        List<ActionRowChildComponent> items = Arrays.stream(components).map(this::resolve).toList();
+        List<ActionRowChildComponent> items = Arrays.stream(components).map(this::resolveActionComponent).toList();
         if (!items.isEmpty()) {
             replyAction.addComponents(ActionRow.of(items));
         }
         return new SendableReply(this);
-    }
-
-    protected ComponentReplacer resolver() {
-        return ComponentReplacer.of(Component.class, _ -> true, this::resolve);
-    }
-
-    private ActionRowChildComponent resolve(Component<?, ?, ?, ?> component) {
-        var className = component.origin().map(Class::getName)
-                .orElseGet(() -> scopedInvocationContext().definition().methodDescription().declaringClass().getName());
-        String definitionId = InteractionDefinition.createDefinitionId(className, component.name());
-
-        var definition = findDefinition(component, definitionId, className);
-
-        int uniqueId = Objects.requireNonNullElse(definition.uniqueId(), -1);
-        ActionRowChildComponent item = switch (definition) {
-            case ButtonDefinition buttonDefinition ->
-                    buttonDefinition.toJDAEntity(createId(definition, component.independent())).withDisabled(!component.enabled());
-            case SelectMenuDefinition<?> menuDefinition ->
-                    menuDefinition.toJDAEntity(createId(definition, component.independent())).withDisabled(!component.enabled());
-        };
-
-        item = switch (component) {
-            case ButtonComponent buttonComponent -> buttonComponent.callback().apply((Button) item);
-            case EntitySelectMenuComponent entitySelectMenuComponent ->
-                    entitySelectMenuComponent.callback().apply(((EntitySelectMenu) item).createCopy()).build();
-            case StringSelectComponent stringSelectComponent ->
-                    stringSelectComponent.callback().apply(((StringSelectMenu) item).createCopy()).build();
-            case UnspecificComponent unspecificComponent -> unspecificComponent.callback().apply(item);
-        };
-
-        if (uniqueId > 0) {
-            item = item.withUniqueId(uniqueId);
-        }
-        item = resolver.resolve(item, scopedUserLocale(), component.placeholder());
-        log.debug("Reply Debug: Adding component \"{}\" to the reply", definition.displayName());
-        return item;
-    }
-
-    private <D extends ComponentDefinition<?>, T extends Component<T, ?, ?, D>> D findDefinition(Component<T, ?, ?, D> component, String definitionId, String className) {
-        InteractionRegistry registry = scopedInteractionRegistry();
-
-        try {
-            // this cast is effective safe
-            D definition = registry.find(component.definitionClass(), false, it ->
-                    it.definitionId().equals(definitionId)
-            );
-
-            return component.build(definition);
-        } catch (IllegalArgumentException e) { // only check if search failed
-            Collection<ModalDefinition> found = registry.find(ModalDefinition.class, it -> it.definitionId().equals(definitionId));
-            if (!found.isEmpty()) {
-                throw new IllegalArgumentException(
-                        JDACException.errorMessage("modal-as-component", entry("method", "%s#%s".formatted(className, component.name())))
-                );
-            }
-            throw e;
-        }
-    }
-
-    private CustomId createId(InteractionDefinition definition, boolean independent) {
-        return independent
-                ? CustomId.independent(definition.definitionId())
-                : new CustomId(scopedRuntime().id(), definition.definitionId());
     }
 }

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/ModalReply.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/ModalReply.java
@@ -1,0 +1,80 @@
+package io.github.kaktushose.jdac.dispatching.reply;
+
+import io.github.kaktushose.jdac.annotations.interactions.Modal;
+import io.github.kaktushose.jdac.definitions.interactions.CustomId;
+import io.github.kaktushose.jdac.definitions.interactions.InteractionDefinition;
+import io.github.kaktushose.jdac.definitions.interactions.ModalDefinition;
+import io.github.kaktushose.jdac.exceptions.InternalException;
+import io.github.kaktushose.jdac.internal.logging.JDACLogger;
+import io.github.kaktushose.jdac.message.placeholder.Entry;
+import io.github.kaktushose.jdac.message.resolver.ComponentResolver;
+import io.github.kaktushose.jdac.message.resolver.MessageResolver;
+import net.dv8tion.jda.api.components.ModalTopLevelComponent;
+import net.dv8tion.jda.api.components.ModalTopLevelComponentUnion;
+import net.dv8tion.jda.api.components.label.Label;
+import net.dv8tion.jda.api.components.label.LabelChildComponent;
+import net.dv8tion.jda.api.components.replacer.ComponentReplacer;
+import net.dv8tion.jda.api.components.tree.ModalComponentTree;
+import net.dv8tion.jda.api.interactions.callbacks.IModalCallback;
+import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+
+import java.util.Collection;
+
+import static io.github.kaktushose.jdac.message.placeholder.Entry.entry;
+import static io.github.kaktushose.jdac.property.internal.IntrospectionAccess.*;
+
+/// Handles all the business logic for sending modal replies.
+@ApiStatus.Internal
+public final class ModalReply extends ActionComponentResolver {
+
+    private static final Logger log = JDACLogger.getLogger(ModalReply.class);
+
+    /// Acknowledgement of this event with a [Modal]. This will open a popup on the target users Discord client.
+    ///
+    /// @param origin       the [Class] the modal handler is defined in
+    /// @param modal        the method name of the [Modal] you want to reply with
+    /// @param components   a [Collection] of [ModalTopLevelComponent]s to add to this modal
+    /// @param placeholders the [Entry] placeholders to use for [message resolution][MessageResolver]
+    /// @throws IllegalArgumentException if no [Modal] with the given name was found
+    public void reply(
+            @Nullable Class<?> origin,
+            String modal,
+            Collection<ModalTopLevelComponent> components,
+            Entry... placeholders
+    ) {
+        if (!(scopedJdaEvent() instanceof IModalCallback callback)) {
+            throw new InternalException("reply-failed", entry("event", scopedJdaEvent().getClass().getName()));
+        }
+        Checks.notEmpty(components, "Modal components");
+
+        InteractionDefinition definition = scopedInvocationContext().definition();
+        String className = origin == null ? definition.classDescription().name() : origin.getName();
+        String definitionId = InteractionDefinition.createDefinitionId(className, modal);
+        ModalDefinition modalDefinition = scopedInteractionRegistry().find(
+                ModalDefinition.class,
+                false,
+                it -> it.definitionId().equals(definitionId)
+        );
+
+        // manual workaround for now
+        ModalComponentTree componentTree = ModalComponentTree.of(components);
+        componentTree = componentTree.replace(ComponentReplacer.of(
+                Label.class,
+                label -> label.getChild() instanceof Component<?, ?, ?, ?>,
+                label -> label.withChild((LabelChildComponent) resolveActionComponent((Component<?, ?, ?, ?>) label.getChild()))
+        ));
+
+        var entryMap = Entry.toMap(placeholders);
+        var resolver = new ComponentResolver<>(scopedMessageResolver(), ModalTopLevelComponentUnion.class);
+        modalDefinition = modalDefinition.with(
+                scopedMessageResolver().resolve(modalDefinition.title(), scopedUserLocale(), entryMap),
+                resolver.resolve(componentTree.getComponents(), scopedUserLocale(), entryMap)
+        );
+
+        log.debug("Replying to interaction \"{}\" with Modal: \"{}\". [Runtime={}]", definition.displayName(), modalDefinition.displayName(), scopedRuntime().id());
+        callback.replyModal(modalDefinition.toJDAEntity(new CustomId(scopedRuntime().id(), definitionId))).complete();
+    }
+}

--- a/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/dynamic/menu/SelectMenuComponent.java
+++ b/core/src/main/java/io/github/kaktushose/jdac/dispatching/reply/dynamic/menu/SelectMenuComponent.java
@@ -3,8 +3,14 @@ package io.github.kaktushose.jdac.dispatching.reply.dynamic.menu;
 import io.github.kaktushose.jdac.definitions.interactions.component.menu.SelectMenuDefinition;
 import io.github.kaktushose.jdac.dispatching.reply.Component;
 import io.github.kaktushose.jdac.message.placeholder.Entry;
+import net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload;
+import net.dv8tion.jda.api.components.checkbox.Checkbox;
+import net.dv8tion.jda.api.components.checkboxgroup.CheckboxGroup;
+import net.dv8tion.jda.api.components.label.LabelChildComponentUnion;
+import net.dv8tion.jda.api.components.radiogroup.RadioGroup;
 import net.dv8tion.jda.api.components.selections.SelectMenu;
 import net.dv8tion.jda.api.components.selections.SelectMenu.Builder;
+import net.dv8tion.jda.api.components.textinput.TextInput;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -22,7 +28,7 @@ import java.util.Objects;
 /// @see StringSelectComponent
 public abstract sealed class SelectMenuComponent<S extends SelectMenuComponent<S, T, B, D>,
         T extends SelectMenu, B extends Builder<T, B>, D extends SelectMenuDefinition<T>> extends Component<S, T, B, D>
-        implements SelectMenu
+        implements SelectMenu, LabelChildComponentUnion
         permits StringSelectComponent, EntitySelectMenuComponent {
 
     protected @Nullable String placeholder;
@@ -107,7 +113,32 @@ public abstract sealed class SelectMenuComponent<S extends SelectMenuComponent<S
     ///
     /// @throws UnsupportedOperationException will always throw
     @Override
-    public @NonNull B createCopy() {
+    public B createCopy() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TextInput asTextInput() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AttachmentUpload asAttachmentUpload() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RadioGroup asRadioGroup() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CheckboxGroup asCheckboxGroup() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Checkbox asCheckbox() {
         throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
## Type
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation

closes #issue

## Description
When replying with modals, action components didn't get resolved. This PR adds this missing logic, enabling the usage of action components within modals as intended. 

### Example
<!-- only fill out for feature prs, or if applicable -->
```java
// code example
```

## Checklist

- [x] Applied IntelliJ Formatter (`Ctrl` + `Shift` + `L`)
- [x] Applied `gradle format`
- [ ] If applicable, added unit tests
- [ ] Updated documentation
